### PR TITLE
Set up planning UI skeleton with calendar and backlog views

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,28 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2020: true
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:react-hooks/recommended',
+    'plugin:@typescript-eslint/recommended'
+  ],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  plugins: ['react-refresh'],
+  rules: {
+    'react/react-in-jsx-scope': 'off',
+    'react/prop-types': 'off'
+  },
+  settings: {
+    react: {
+      version: 'detect'
+    }
+  }
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.DS_Store
+dist
+*.local
+.env
+.env.*
+.netlify

--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# GEP Group · Planificación
+
+Primera iteración del ERP interno enfocado en la planificación de formaciones. Incluye la estructura base del frontend en React + TypeScript con Vite, estilos iniciales alineados con el branding de GEP Group, un calendario FullCalendar vacío y la vista de "Presupuestos sin fecha" alimentada desde Pipedrive a través de una función serverless de Netlify.
+
+## Tecnologías principales
+
+- [React](https://react.dev/) + [TypeScript](https://www.typescriptlang.org/)
+- [Vite](https://vitejs.dev/) como bundler
+- [Bootstrap 5](https://getbootstrap.com/) y [React Bootstrap](https://react-bootstrap.netlify.app/) para componentes UI
+- [FullCalendar](https://fullcalendar.io/) para la visualización del calendario
+- [@tanstack/react-query](https://tanstack.com/query/latest) para la gestión de datos asincrónicos
+- Netlify Functions para ocultar las credenciales y centralizar el acceso a Pipedrive
+
+## Puesta en marcha
+
+1. Instala las dependencias
+   ```bash
+   npm install
+   ```
+2. Define las variables de entorno necesarias (por ejemplo, en Netlify o un archivo `.env.local` si usas `netlify dev`):
+   ```bash
+   PIPEDRIVE_API_URL=https://api.pipedrive.com/v1
+   PIPEDRIVE_API_TOKEN=TU_TOKEN
+   ```
+3. Levanta el entorno de desarrollo con Vite:
+   ```bash
+   npm run dev
+   ```
+4. Opcionalmente, ejecuta la función serverless en local con [`netlify dev`](https://docs.netlify.com/cli/get-started/) para evitar problemas de CORS.
+
+## Despliegue en Netlify
+
+El archivo [`netlify/functions/deals.ts`](netlify/functions/deals.ts) expone el endpoint `/.netlify/functions/deals`, que devuelve los presupuestos del embudo 3, resolviendo el campo personalizado de "Sede" y filtrando los productos cuyo código comienza por `form-`.
+
+La configuración recomendada de Netlify es:
+
+```toml
+[build]
+  command = "npm run build"
+  publish = "dist"
+  functions = "netlify/functions"
+```
+
+## Próximos pasos sugeridos
+
+- Sincronizar eventos reales en el calendario a partir de las fechas planificadas.
+- Permitir que los usuarios asignen fechas desde la vista de "Sin fecha" y reflejarlo en Pipedrive.
+- Añadir filtros y búsqueda avanzada por cliente, sede o tipo de formación.
+- Integrar progresivamente las APIs de Holded y WooCommerce.
+- Incorporar la carga y gestión de documentación mediante Google Workspace.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GEP Group · Planificación</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,13 @@
+[build]
+  command = "npm run build"
+  publish = "dist"
+  functions = "netlify/functions"
+
+[dev]
+  command = "npm run dev"
+  port = 5173
+
+[[redirects]]
+  from = "/api/*"
+  to = "/.netlify/functions/:splat"
+  status = 200

--- a/netlify/functions/deals.ts
+++ b/netlify/functions/deals.ts
@@ -1,0 +1,195 @@
+import type { Handler } from '@netlify/functions';
+
+const API_URL = process.env.PIPEDRIVE_API_URL;
+const API_TOKEN = process.env.PIPEDRIVE_API_TOKEN;
+const DEFAULT_STAGE_ID = 3;
+const SEDE_FIELD_KEY = '676d6bd51e52999c582c01f67c99a35ed30bf6ae';
+
+interface PipedriveDeal {
+  id: number;
+  title: string;
+  org_id?: { value?: number; name?: string } | number | null;
+  org_name?: string | null;
+  [key: string]: unknown;
+}
+
+interface DealProductItem {
+  product?: {
+    name?: string;
+    code?: string;
+  };
+}
+
+interface NormalisedDeal {
+  id: number;
+  title: string;
+  clientId: number | null;
+  clientName: string | null;
+  sede: string | null;
+  formations: string[];
+}
+
+const defaultHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Content-Type': 'application/json'
+};
+
+const buildUrl = (path: string, params: Record<string, string | number | undefined>) => {
+  if (!API_URL) {
+    throw new Error('Falta la variable PIPEDRIVE_API_URL');
+  }
+
+  const url = new URL(path, API_URL.endsWith('/') ? API_URL : `${API_URL}/`);
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      url.searchParams.set(key, String(value));
+    }
+  });
+
+  if (API_TOKEN) {
+    url.searchParams.set('api_token', API_TOKEN);
+  }
+
+  return url.toString();
+};
+
+const fetchJson = async <T>(path: string, params: Record<string, string | number | undefined> = {}): Promise<T> => {
+  const response = await fetch(buildUrl(path, params));
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Error ${response.status} en Pipedrive: ${text}`);
+  }
+
+  return (await response.json()) as T;
+};
+
+const loadSedeOptions = async (): Promise<Map<string, string>> => {
+  type FieldOption = { id: number | string; label: string };
+  type FieldResponse = { data?: { options?: FieldOption[] } | null };
+
+  try {
+    const field = await fetchJson<FieldResponse>(`dealFields/${SEDE_FIELD_KEY}`, {});
+    const options = field.data?.options ?? [];
+    const map = new Map<string, string>();
+
+    options.forEach((option) => {
+      map.set(String(option.id), option.label);
+    });
+
+    return map;
+  } catch (error) {
+    console.error('No se pudieron cargar las opciones del campo Sede', error);
+    return new Map<string, string>();
+  }
+};
+
+const extractClient = (deal: PipedriveDeal): { id: number | null; name: string | null } => {
+  const org = deal.org_id;
+  if (typeof org === 'number') {
+    return { id: org, name: deal.org_name ?? null };
+  }
+
+  if (org && typeof org === 'object') {
+    return {
+      id: typeof org.value === 'number' ? org.value : null,
+      name: typeof org.name === 'string' ? org.name : deal.org_name ?? null
+    };
+  }
+
+  return {
+    id: null,
+    name: deal.org_name ?? null
+  };
+};
+
+const fetchDealProducts = async (dealId: number): Promise<string[]> => {
+  type ProductsResponse = { data?: DealProductItem[] | null };
+
+  try {
+    const productsResponse = await fetchJson<ProductsResponse>(`deals/${dealId}/products`, {});
+    const items = productsResponse.data ?? [];
+
+    return items
+      .map((item) => item.product)
+      .filter((product): product is NonNullable<DealProductItem['product']> => Boolean(product?.name))
+      .filter((product) => (product.code ?? '').toLowerCase().startsWith('form-'))
+      .map((product) => product.name!.trim())
+      .filter((name, index, array) => name.length > 0 && array.indexOf(name) === index);
+  } catch (error) {
+    console.error(`No se pudieron obtener los productos del deal ${dealId}`, error);
+    return [];
+  }
+};
+
+const loadDeals = async (stageId: number): Promise<NormalisedDeal[]> => {
+  type DealsResponse = { data?: PipedriveDeal[] | null };
+
+  const [sedeOptions, dealsResponse] = await Promise.all([
+    loadSedeOptions(),
+    fetchJson<DealsResponse>('deals', {
+      stage_id: stageId,
+      limit: 500,
+      status: 'all_not_deleted',
+      sort: 'update_time DESC'
+    })
+  ]);
+
+  const deals = dealsResponse.data ?? [];
+  const normalised: NormalisedDeal[] = [];
+
+  for (const deal of deals) {
+    const client = extractClient(deal);
+    const sedeRaw = (deal as Record<string, unknown>)[SEDE_FIELD_KEY];
+    const sedeLabel = sedeRaw != null ? sedeOptions.get(String(sedeRaw)) ?? null : null;
+    const formations = await fetchDealProducts(deal.id);
+
+    normalised.push({
+      id: deal.id,
+      title: deal.title,
+      clientId: client.id,
+      clientName: client.name,
+      sede: sedeLabel,
+      formations
+    });
+  }
+
+  return normalised;
+};
+
+export const handler: Handler = async (event) => {
+  try {
+    if (!API_TOKEN || !API_URL) {
+      return {
+        statusCode: 500,
+        headers: defaultHeaders,
+        body: JSON.stringify({ message: 'Faltan las credenciales de Pipedrive en el entorno.' })
+      };
+    }
+
+    const stageParam = event.queryStringParameters?.stageId;
+    const stageId = stageParam ? Number.parseInt(stageParam, 10) || DEFAULT_STAGE_ID : DEFAULT_STAGE_ID;
+
+    const deals = await loadDeals(stageId);
+
+    return {
+      statusCode: 200,
+      headers: defaultHeaders,
+      body: JSON.stringify({ deals })
+    };
+  } catch (error) {
+    console.error('Error al cargar los presupuestos de Pipedrive', error);
+
+    return {
+      statusCode: 500,
+      headers: defaultHeaders,
+      body: JSON.stringify({
+        message: 'No se pudieron cargar los presupuestos desde Pipedrive.',
+        detail: error instanceof Error ? error.message : 'Error desconocido'
+      })
+    };
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "gep-group-planificacion",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@fullcalendar/daygrid": "^6.1.15",
+    "@fullcalendar/interaction": "^6.1.15",
+    "@fullcalendar/list": "^6.1.15",
+    "@fullcalendar/react": "^6.1.15",
+    "@fullcalendar/timegrid": "^6.1.15",
+    "@tanstack/react-query": "^5.45.1",
+    "bootstrap": "^5.3.3",
+    "react": "^18.3.1",
+    "react-bootstrap": "^2.10.4",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.10",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@typescript-eslint/eslint-plugin": "^7.18.0",
+    "@typescript-eslint/parser": "^7.18.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "eslint": "^8.57.0",
+    "eslint-plugin-react": "^7.35.0",
+    "eslint-plugin-react-hooks": "^4.6.2",
+    "eslint-plugin-react-refresh": "^0.4.7",
+    "sass": "^1.77.6",
+    "typescript": "^5.5.3",
+    "vite": "^5.3.4"
+  }
+}

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#004a9f" />
+      <stop offset="100%" stop-color="#00a0df" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="12" fill="url(#g)" />
+  <path d="M18 44L30 20l6 12 10-20 8 32" stroke="#fff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+</svg>

--- a/src/App.scss
+++ b/src/App.scss
@@ -1,0 +1,29 @@
+.app-shell {
+  min-height: 100vh;
+  background: var(--surface-muted);
+  color: var(--text-primary);
+}
+
+.app-main {
+  margin-top: 0;
+}
+
+.calendar-card,
+.deals-card {
+  background: var(--surface-base);
+  border-radius: 1rem;
+  box-shadow: var(--shadow-soft);
+  padding: 1.5rem;
+}
+
+.calendar-card .fc,
+.deals-card table {
+  font-size: 0.95rem;
+}
+
+@media (max-width: 768px) {
+  .calendar-card,
+  .deals-card {
+    padding: 1rem;
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+import Container from 'react-bootstrap/Container';
+import Stack from 'react-bootstrap/Stack';
+import CalendarView from './components/calendar/CalendarView.tsx';
+import DealsBoard from './components/deals/DealsBoard.tsx';
+import HeaderBar from './components/layout/HeaderBar.tsx';
+import './App.scss';
+
+type TabKey = 'calendar' | 'backlog';
+
+const App = () => {
+  const [activeTab, setActiveTab] = useState<TabKey>('calendar');
+
+  return (
+    <div className="app-shell">
+      <HeaderBar onNavigate={setActiveTab} activeKey={activeTab} />
+      <main className="app-main">
+        <Container fluid className="pt-4 pb-5">
+          <Stack gap={4}>
+            {activeTab === 'calendar' ? <CalendarView /> : <DealsBoard />}
+          </Stack>
+        </Container>
+      </main>
+    </div>
+  );
+};
+
+export default App;

--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -1,0 +1,44 @@
+import FullCalendar from '@fullcalendar/react';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import timeGridPlugin from '@fullcalendar/timegrid';
+import listPlugin from '@fullcalendar/list';
+import interactionPlugin from '@fullcalendar/interaction';
+import esLocale from '@fullcalendar/core/locales/es';
+import Card from 'react-bootstrap/Card';
+
+const CalendarView = () => (
+  <Card className="calendar-card border-0">
+    <Card.Body>
+      <div className="d-flex justify-content-between align-items-start flex-wrap gap-3 mb-4">
+        <div>
+          <Card.Title as="h2" className="h4 mb-1 text-primary fw-semibold">
+            Calendario de formaciones
+          </Card.Title>
+          <Card.Subtitle className="text-secondary">
+            Consulta por mes, semana, día o vista agenda.
+          </Card.Subtitle>
+        </div>
+      </div>
+      <FullCalendar
+        plugins={[dayGridPlugin, timeGridPlugin, listPlugin, interactionPlugin]}
+        initialView="timeGridWeek"
+        headerToolbar={{
+          left: 'prev,next today',
+          center: 'title',
+          right: 'dayGridMonth,timeGridWeek,timeGridDay,listWeek'
+        }}
+        height="auto"
+        weekends
+        selectable={false}
+        editable={false}
+        slotDuration="00:30:00"
+        nowIndicator
+        events={[]}
+        locales={[esLocale]}
+        locale="es"
+      />
+    </Card.Body>
+  </Card>
+);
+
+export default CalendarView;

--- a/src/components/deals/DealsBoard.tsx
+++ b/src/components/deals/DealsBoard.tsx
@@ -1,0 +1,106 @@
+import { useQuery } from '@tanstack/react-query';
+import Alert from 'react-bootstrap/Alert';
+import Badge from 'react-bootstrap/Badge';
+import Button from 'react-bootstrap/Button';
+import Card from 'react-bootstrap/Card';
+import Placeholder from 'react-bootstrap/Placeholder';
+import Stack from 'react-bootstrap/Stack';
+import Table from 'react-bootstrap/Table';
+import { fetchDeals, DealRecord } from '../../services/deals.ts';
+
+const renderRow = (deal: DealRecord) => (
+  <tr key={deal.id}>
+    <td className="fw-semibold text-primary">#{deal.id}</td>
+    <td>{deal.title}</td>
+    <td>{deal.clientName ?? 'Sin organización asociada'}</td>
+    <td>{deal.sede ?? 'Sin sede definida'}</td>
+    <td className="text-nowrap">
+      {deal.formations.length > 0 ? (
+        <Stack direction="horizontal" gap={2} className="flex-wrap">
+          {deal.formations.map((name) => (
+            <Badge key={name} bg="info" text="dark" className="px-3 py-2 rounded-pill">
+              {name}
+            </Badge>
+          ))}
+        </Stack>
+      ) : (
+        <span className="text-muted">Sin formaciones form-</span>
+      )}
+    </td>
+  </tr>
+);
+
+const DealsBoard = () => {
+  const { data, isLoading, isError, error, refetch } = useQuery({
+    queryKey: ['deals', 'stage-3'],
+    queryFn: fetchDeals,
+    staleTime: 1000 * 60
+  });
+
+  return (
+    <Card className="deals-card border-0" role="region" aria-live="polite">
+      <Card.Body>
+        <div className="d-flex justify-content-between align-items-start flex-wrap gap-3 mb-4">
+          <div>
+            <Card.Title as="h2" className="h4 mb-1 text-primary fw-semibold">
+              Presupuestos sin fecha asignada
+            </Card.Title>
+            <Card.Subtitle className="text-secondary">
+              Embudo 3 · datos actualizados desde Pipedrive.
+            </Card.Subtitle>
+          </div>
+          <Button variant="outline-primary" onClick={() => refetch()}>
+            Recargar datos
+          </Button>
+        </div>
+
+        {isError && (
+          <Alert variant="danger" className="mb-4" role="alert">
+            Ocurrió un error al sincronizar los presupuestos.
+            <div className="small text-muted">{error instanceof Error ? error.message : 'Intenta de nuevo más tarde.'}</div>
+          </Alert>
+        )}
+
+        <div className="table-responsive">
+          <Table hover className="align-middle mb-0">
+            <thead>
+              <tr>
+                <th scope="col">Presupuesto</th>
+                <th scope="col">Título</th>
+                <th scope="col">Cliente</th>
+                <th scope="col">Sede</th>
+                <th scope="col">Formación</th>
+              </tr>
+            </thead>
+            <tbody>
+              {isLoading && (
+                <>
+                  {Array.from({ length: 4 }).map((_, index) => (
+                    <tr key={`skeleton-${index}`}>
+                      {Array.from({ length: 5 }).map((__, cell) => (
+                        <td key={cell}>
+                          <Placeholder animation="wave" xs={12} className="rounded-pill" />
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </>
+              )}
+
+              {!isLoading && data && data.length > 0 && data.map(renderRow)}
+            </tbody>
+          </Table>
+        </div>
+
+        {!isLoading && data && data.length === 0 && !isError && (
+          <div className="text-center py-5 text-secondary">
+            <p className="fw-semibold">No hay presupuestos en el embudo seleccionado.</p>
+            <p className="mb-0">En cuanto un presupuesto se marque como ganado en Pipedrive, aparecerá automáticamente aquí.</p>
+          </div>
+        )}
+      </Card.Body>
+    </Card>
+  );
+};
+
+export default DealsBoard;

--- a/src/components/layout/HeaderBar.tsx
+++ b/src/components/layout/HeaderBar.tsx
@@ -1,0 +1,54 @@
+import Container from 'react-bootstrap/Container';
+import Nav from 'react-bootstrap/Nav';
+import Navbar from 'react-bootstrap/Navbar';
+import Badge from 'react-bootstrap/Badge';
+
+interface HeaderBarProps {
+  activeKey: 'calendar' | 'backlog';
+  onNavigate: (key: 'calendar' | 'backlog') => void;
+}
+
+const HeaderBar = ({ activeKey, onNavigate }: HeaderBarProps) => (
+  <header className="app-header shadow-sm">
+    <Navbar bg="white" className="py-3" expand="lg">
+      <Container fluid>
+        <Navbar.Brand className="d-flex align-items-center gap-2 fw-semibold text-uppercase text-primary">
+          <img src="/favicon.svg" width="32" height="32" alt="GEP Group" />
+          <span>GEP Group · Planificación</span>
+        </Navbar.Brand>
+        <div className="d-none d-lg-block">
+          <Badge bg="primary" pill className="text-uppercase tracking-wide">
+            Primera iteración
+          </Badge>
+        </div>
+      </Container>
+    </Navbar>
+    <div className="border-top border-bottom bg-white">
+      <Container fluid>
+        <Nav
+          activeKey={activeKey}
+          onSelect={(eventKey) => {
+            if (eventKey === 'calendar' || eventKey === 'backlog') {
+              onNavigate(eventKey);
+            }
+          }}
+          className="nav-tabs-clean"
+          role="tablist"
+        >
+          <Nav.Item>
+            <Nav.Link eventKey="calendar" role="tab">
+              Calendario
+            </Nav.Link>
+          </Nav.Item>
+          <Nav.Item>
+            <Nav.Link eventKey="backlog" role="tab">
+              Sin fecha
+            </Nav.Link>
+          </Nav.Item>
+        </Nav>
+      </Container>
+    </div>
+  </header>
+);
+
+export default HeaderBar;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import App from './App.tsx';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import './styles/theme.scss';
+
+const queryClient = new QueryClient();
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </React.StrictMode>
+);

--- a/src/services/deals.ts
+++ b/src/services/deals.ts
@@ -1,0 +1,24 @@
+export interface DealRecord {
+  id: number;
+  title: string;
+  clientId: number | null;
+  clientName: string | null;
+  sede: string | null;
+  formations: string[];
+}
+
+interface DealsResponse {
+  deals: DealRecord[];
+}
+
+export const fetchDeals = async (): Promise<DealRecord[]> => {
+  const response = await fetch('/.netlify/functions/deals');
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || 'No se pudo obtener la lista de presupuestos.');
+  }
+
+  const payload = (await response.json()) as DealsResponse;
+  return payload.deals ?? [];
+};

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -1,0 +1,92 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap');
+
+:root {
+  --brand-primary: #004c97;
+  --brand-secondary: #0097c7;
+  --brand-accent: #f9b233;
+  --surface-base: #ffffff;
+  --surface-muted: #f4f7fb;
+  --text-primary: #1f2937;
+  --text-secondary: #6b7280;
+  --shadow-soft: 0 22px 45px rgba(15, 23, 42, 0.08);
+}
+
+body {
+  font-family: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: var(--surface-muted);
+  color: var(--text-primary);
+}
+
+.text-primary {
+  color: var(--brand-primary) !important;
+}
+
+.btn-primary,
+.badge.bg-primary {
+  background: var(--brand-primary) !important;
+  border-color: var(--brand-primary) !important;
+}
+
+.btn-outline-primary {
+  color: var(--brand-primary);
+  border-color: var(--brand-primary);
+}
+
+.btn-outline-primary:hover,
+.btn-outline-primary:focus {
+  color: #fff;
+  background: var(--brand-primary);
+  border-color: var(--brand-primary);
+}
+
+.nav-tabs-clean .nav-link {
+  padding: 0.85rem 1.5rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  border: none;
+  border-bottom: 3px solid transparent;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.nav-tabs-clean .nav-link.active,
+.nav-tabs-clean .nav-link:focus,
+.nav-tabs-clean .nav-link:hover {
+  color: var(--brand-primary);
+  border-color: var(--brand-primary);
+  background-color: transparent;
+}
+
+.badge.bg-info {
+  background: rgba(0, 151, 199, 0.2) !important;
+}
+
+.tracking-wide {
+  letter-spacing: 0.12em;
+}
+
+.fc .fc-toolbar-title {
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: var(--brand-primary);
+}
+
+.fc .fc-button-primary {
+  background: var(--brand-primary);
+  border-color: var(--brand-primary);
+}
+
+.fc .fc-button-primary:not(:disabled):hover {
+  background: var(--brand-secondary);
+  border-color: var(--brand-secondary);
+}
+
+.fc .fc-daygrid-day-number,
+.fc .fc-col-header-cell-cushion {
+  color: var(--text-secondary);
+}
+
+.fc-theme-standard td,
+.fc-theme-standard th {
+  border-color: rgba(15, 23, 42, 0.08);
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/star
+++ b/star
@@ -1,7 +1,0 @@
-echo "# ERP" >> README.md
-git init
-git add README.md
-git commit -m "first commit"
-git branch -M main
-git remote add origin https://github.com/JulioGEP/ERP.git
-git push -u origin main

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["node"]
+  },
+  "include": ["src", "netlify/functions"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true,
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts", "netlify/functions/**/*.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a React + TypeScript Vite project with Bootstrap styling aligned to the GEP Group branding
- add a calendar screen using FullCalendar and a "Sin fecha" backlog fed from a Netlify function with React Query
- implement the Netlify serverless function that proxies Pipedrive stage 3 deals, resolves the custom Sede field and filters form-* products

## Testing
- npm install --registry https://registry.npmmirror.com *(fails: npm error code E403)*

------
https://chatgpt.com/codex/tasks/task_e_68d0614df7f88328b41564e7cf884e4b