### PR TITLE
Fix Netlify build issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@fullcalendar/interaction": "^6.1.15",
     "@fullcalendar/list": "^6.1.15",
     "@fullcalendar/react": "^6.1.15",
+    "@netlify/functions": "^2.7.0",
     "@fullcalendar/timegrid": "^6.1.15",
     "@tanstack/react-query": "^5.45.1",
     "bootstrap": "^5.3.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 import Container from 'react-bootstrap/Container';
 import Stack from 'react-bootstrap/Stack';
-import CalendarView from './components/calendar/CalendarView.tsx';
-import DealsBoard from './components/deals/DealsBoard.tsx';
-import HeaderBar from './components/layout/HeaderBar.tsx';
+import CalendarView from './components/calendar/CalendarView';
+import DealsBoard from './components/deals/DealsBoard';
+import HeaderBar from './components/layout/HeaderBar';
 import './App.scss';
 
 type TabKey = 'calendar' | 'backlog';

--- a/src/components/deals/DealsBoard.tsx
+++ b/src/components/deals/DealsBoard.tsx
@@ -6,7 +6,7 @@ import Card from 'react-bootstrap/Card';
 import Placeholder from 'react-bootstrap/Placeholder';
 import Stack from 'react-bootstrap/Stack';
 import Table from 'react-bootstrap/Table';
-import { fetchDeals, DealRecord } from '../../services/deals.ts';
+import { fetchDeals, DealRecord } from '../../services/deals';
 
 const renderRow = (deal: DealRecord) => (
   <tr key={deal.id}>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import App from './App.tsx';
+import App from './App';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import './styles/theme.scss';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["node"]
+    "types": ["node", "@netlify/functions"]
   },
   "include": ["src", "netlify/functions"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -4,7 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "allowSyntheticDefaultImports": true,
-    "types": ["node"]
+    "types": ["node", "@netlify/functions"]
   },
   "include": ["vite.config.ts", "netlify/functions/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- add the `@netlify/functions` package so the Netlify handler can be resolved at build time and expose its types to TypeScript
- drop explicit `.ts`/`.tsx` extensions from local imports so that the default compiler configuration accepts the paths
- register Netlify function types in the TypeScript project configs used for both the app and the functions build

## Testing
- `npm run build` *(fails locally: dependencies cannot be installed in this offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d06b1677c08328816d45f2c947d8a2