### PR TITLE
Fix Netlify function build output location

### DIFF
--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -5,7 +5,9 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "allowSyntheticDefaultImports": true,
-    "types": ["node", "@netlify/functions"]
+    "types": ["node", "@netlify/functions"],
+    "outDir": "./.netlify/tsc",
+    "declarationDir": "./.netlify/tsc"
   },
   "include": ["vite.config.ts", "netlify/functions/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- redirect the TypeScript build output for Netlify functions into a hidden .netlify folder so generated declaration files no longer appear alongside the source
- prevent Netlify from detecting a spurious `deals.d` function during deployment

## Testing
- not run (npm install fails in this environment due to restricted access to the npm registry)


------
https://chatgpt.com/codex/tasks/task_e_68d06e9b47f083288b0f6aa4eb42bceb