### PR TITLE
Adjust calendar view positioning and default scroll

### DIFF
--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -8,17 +8,7 @@ import Card from 'react-bootstrap/Card';
 
 const CalendarView = () => (
   <Card className="calendar-card border-0">
-    <Card.Body>
-      <div className="d-flex justify-content-between align-items-start flex-wrap gap-3 mb-4">
-        <div>
-          <Card.Title as="h2" className="h4 mb-1 text-primary fw-semibold">
-            Calendario de formaciones
-          </Card.Title>
-          <Card.Subtitle className="text-secondary">
-            Consulta por mes, semana, día o vista agenda.
-          </Card.Subtitle>
-        </div>
-      </div>
+    <Card.Body className="p-0">
       <FullCalendar
         plugins={[dayGridPlugin, timeGridPlugin, listPlugin, interactionPlugin]}
         initialView="timeGridWeek"
@@ -32,6 +22,7 @@ const CalendarView = () => (
         selectable={false}
         editable={false}
         slotDuration="00:30:00"
+        scrollTime="06:00:00"
         nowIndicator
         events={[]}
         locales={[esLocale]}


### PR DESCRIPTION
## Summary
- remove the calendar header text so the grid starts higher on the page
- drop extra card body padding and configure the calendar to scroll to 06:00 by default

## Testing
- npm run build *(fails: missing @netlify/functions type definitions; cannot install dependency due to registry access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d077cc25f483288a80e335a2661dfd