### PR TITLE
Remove Primera iteración references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GEP Group · Planificación
 
-Primera iteración del ERP interno enfocado en la planificación de formaciones. Incluye la estructura base del frontend en React + TypeScript con Vite, estilos iniciales alineados con el branding de GEP Group, un calendario FullCalendar vacío y la vista de "Presupuestos sin fecha" alimentada desde Pipedrive a través de una función serverless de Netlify.
+ERP interno enfocado en la planificación de formaciones. Incluye la estructura base del frontend en React + TypeScript con Vite, estilos iniciales alineados con el branding de GEP Group, un calendario FullCalendar vacío y la vista de "Presupuestos sin fecha" alimentada desde Pipedrive a través de una función serverless de Netlify.
 
 ## Tecnologías principales
 

--- a/src/components/layout/HeaderBar.tsx
+++ b/src/components/layout/HeaderBar.tsx
@@ -1,7 +1,6 @@
 import Container from 'react-bootstrap/Container';
 import Nav from 'react-bootstrap/Nav';
 import Navbar from 'react-bootstrap/Navbar';
-import Badge from 'react-bootstrap/Badge';
 import logo from '../../styles/GEP-Group_Logotipo_horizontal.png';
 
 interface HeaderBarProps {
@@ -17,11 +16,6 @@ const HeaderBar = ({ activeKey, onNavigate }: HeaderBarProps) => (
           <img src={logo} alt="GEP Group" height={40} />
           <span>GEP Group · Planificación</span>
         </Navbar.Brand>
-        <div className="d-none d-lg-block">
-          <Badge pill className="app-header-badge text-uppercase tracking-wide">
-            Primera iteración
-          </Badge>
-        </div>
       </Container>
     </Navbar>
     <div className="app-header-nav">


### PR DESCRIPTION
## Summary
- remove the "Primera iteración" badge from the header layout
- update the README introduction to drop the "Primera iteración" phrasing

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d0fdeb0c78832897446c42e15f7457