### PR TITLE
Restore weekly calendar scrolling

### DIFF
--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -17,7 +17,6 @@ const CalendarView = () => (
           center: 'title',
           right: 'dayGridMonth,timeGridWeek,timeGridDay,listWeek'
         }}
-        height="auto"
         weekends
         selectable={false}
         editable={false}


### PR DESCRIPTION
## Summary
- remove the fixed auto height from the weekly FullCalendar view so the built-in time grid scroller is restored while keeping the initial 06:00 focus

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0fdbb2e988328aebcebeb8828dd3c