### PR TITLE
feat: allow uploading deals manually

### DIFF
--- a/src/services/deals.ts
+++ b/src/services/deals.ts
@@ -11,14 +11,44 @@ interface DealsResponse {
   deals: DealRecord[];
 }
 
+interface DealResponse {
+  deal?: DealRecord | null;
+  message?: string;
+}
+
+const parseErrorMessage = async (response: Response) => {
+  try {
+    const payload = (await response.json()) as { message?: string };
+    return payload.message ?? 'No se pudo obtener la lista de presupuestos.';
+  } catch (error) {
+    const text = await response.text();
+    return text || 'No se pudo obtener la lista de presupuestos.';
+  }
+};
+
 export const fetchDeals = async (): Promise<DealRecord[]> => {
   const response = await fetch('/.netlify/functions/deals');
 
   if (!response.ok) {
-    const message = await response.text();
-    throw new Error(message || 'No se pudo obtener la lista de presupuestos.');
+    throw new Error(await parseErrorMessage(response));
   }
 
   const payload = (await response.json()) as DealsResponse;
   return payload.deals ?? [];
+};
+
+export const fetchDealById = async (dealId: number): Promise<DealRecord> => {
+  const response = await fetch(`/.netlify/functions/deals?dealId=${dealId}`);
+
+  if (!response.ok) {
+    throw new Error(await parseErrorMessage(response));
+  }
+
+  const payload = (await response.json()) as DealResponse;
+
+  if (!payload.deal) {
+    throw new Error(payload.message || 'No se encontró el presupuesto solicitado.');
+  }
+
+  return payload.deal;
 };


### PR DESCRIPTION
## Summary
- add Netlify function support to retrieve a single deal by id and reuse deal normalisation
- expose a client helper to fetch one deal and handle API error responses
- add "Subir Deal" action in the backlog view to prompt for an id, fetch it and prepend the result with user feedback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d11d605c508328aff01666e473642e