### PR TITLE
Allow calendar week view to scroll to midnight

### DIFF
--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -22,7 +22,7 @@ const CalendarView = () => (
           selectable={false}
           editable={false}
           slotDuration="00:30:00"
-          slotMinTime="06:00:00"
+          slotMinTime="00:00:00"
           scrollTime="06:00:00"
           height="parent"
           nowIndicator


### PR DESCRIPTION
## Summary
- allow the weekly time grid to scroll back to midnight while still starting at 06:00

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1210101988328a9d7734a8ec5ca28