### PR TITLE
Add detailed deal modal and scheduling support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 .DS_Store
 dist
+tsconfig.tsbuildinfo
 *.local
 .env
 .env.*

--- a/netlify/functions/deals.ts
+++ b/netlify/functions/deals.ts
@@ -4,20 +4,92 @@ const API_URL = process.env.PIPEDRIVE_API_URL;
 const API_TOKEN = process.env.PIPEDRIVE_API_TOKEN;
 const DEFAULT_STAGE_ID = 3;
 const SEDE_FIELD_KEY = '676d6bd51e52999c582c01f67c99a35ed30bf6ae';
+const ADDRESS_FIELD_KEY = '8b2a7570f5ba8aa4754f061cd9dc92fd778376a7';
+const RECOMMENDED_HOURS_FIELD_KEY = '38f11c8876ecde803a027fbf3c9041fda2ae7eb7';
+const TRAINING_CODE_PREFIX = 'form-';
 
 interface PipedriveDeal {
   id: number;
   title: string;
+  pipeline_id?: number | string | null;
   org_id?: { value?: number; name?: string } | number | null;
   org_name?: string | null;
   [key: string]: unknown;
 }
 
 interface DealProductItem {
-  product?: {
-    name?: string;
-    code?: string;
-  };
+  id?: number | string | null;
+  product_id?: number | string | null;
+  quantity?: number | string | null;
+  name?: string | null;
+  code?: string | null;
+  item_price?: number | string | null;
+  product?: PipedriveProduct | null;
+  [key: string]: unknown;
+}
+
+interface PipedriveProduct {
+  id?: number;
+  name?: string | null;
+  code?: string | null;
+  description?: string | null;
+  [key: string]: unknown;
+}
+
+interface PipedriveNote {
+  id?: number;
+  content?: string | null;
+  add_time?: string | null;
+  user_id?: { name?: string | null } | number | null;
+  [key: string]: unknown;
+}
+
+interface PipedriveFile {
+  id?: number;
+  file_name?: string | null;
+  url?: string | null;
+  download_url?: string | null;
+  file_type?: string | null;
+  add_time?: string | null;
+  user_id?: { name?: string | null } | number | null;
+  [key: string]: unknown;
+}
+
+interface NormalisedNote {
+  id: string;
+  content: string;
+  createdAt: string | null;
+  authorName: string | null;
+  source: 'deal' | 'product';
+  productId: number | null;
+  dealProductId: number | null;
+}
+
+interface NormalisedAttachment {
+  id: string;
+  name: string;
+  url: string;
+  downloadUrl: string | null;
+  fileType: string | null;
+  addedAt: string | null;
+  addedBy: string | null;
+  source: 'deal' | 'product';
+  productId: number | null;
+  dealProductId: number | null;
+}
+
+interface NormalisedProduct {
+  dealProductId: number;
+  productId: number | null;
+  name: string;
+  code: string | null;
+  quantity: number;
+  itemPrice: number | null;
+  recommendedHours: number | null;
+  recommendedHoursRaw: string | null;
+  notes: NormalisedNote[];
+  attachments: NormalisedAttachment[];
+  isTraining: boolean;
 }
 
 interface NormalisedDeal {
@@ -26,7 +98,14 @@ interface NormalisedDeal {
   clientId: number | null;
   clientName: string | null;
   sede: string | null;
+  address: string | null;
+  pipelineId: number | null;
+  pipelineName: string | null;
   formations: string[];
+  trainingProducts: NormalisedProduct[];
+  extraProducts: NormalisedProduct[];
+  notes: NormalisedNote[];
+  attachments: NormalisedAttachment[];
 }
 
 const defaultHeaders = {
@@ -67,6 +146,125 @@ const fetchJson = async <T>(path: string, params: Record<string, string | number
   return (await response.json()) as T;
 };
 
+const toNumber = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const normalised = value.replace(/,/g, '.');
+    const parsed = Number.parseFloat(normalised);
+
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+};
+
+const toInteger = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isInteger(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+};
+
+const cleanNoteContent = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  const withoutTags = value.replace(/<[^>]*>/g, ' ');
+  return withoutTags.replace(/\s+/g, ' ').trim();
+};
+
+const parseAuthorName = (value: unknown): string | null => {
+  if (typeof value === 'object' && value !== null && 'name' in value) {
+    const name = (value as { name?: unknown }).name;
+    if (typeof name === 'string' && name.trim().length > 0) {
+      return name.trim();
+    }
+  }
+
+  return null;
+};
+
+const normaliseNote = (
+  note: PipedriveNote,
+  source: 'deal' | 'product',
+  context: { productId?: number | null; dealProductId?: number | null } = {}
+): NormalisedNote => ({
+  id: note.id != null ? String(note.id) : `${source}-${Math.random().toString(36).slice(2)}`,
+  content: cleanNoteContent(note.content),
+  createdAt: typeof note.add_time === 'string' ? note.add_time : null,
+  authorName: parseAuthorName(note.user_id),
+  source,
+  productId: context.productId ?? null,
+  dealProductId: context.dealProductId ?? null
+});
+
+const normaliseAttachment = (
+  file: PipedriveFile,
+  source: 'deal' | 'product',
+  context: { productId?: number | null; dealProductId?: number | null } = {}
+): NormalisedAttachment | null => {
+  const url = typeof file.url === 'string' && file.url.trim().length > 0 ? file.url.trim() : null;
+
+  if (!url) {
+    return null;
+  }
+
+  const name = typeof file.file_name === 'string' && file.file_name.trim().length > 0 ? file.file_name.trim() : 'Documento';
+
+  return {
+    id: file.id != null ? String(file.id) : `${source}-${Math.random().toString(36).slice(2)}`,
+    name,
+    url,
+    downloadUrl: typeof file.download_url === 'string' && file.download_url.trim().length > 0 ? file.download_url.trim() : null,
+    fileType: typeof file.file_type === 'string' ? file.file_type : null,
+    addedAt: typeof file.add_time === 'string' ? file.add_time : null,
+    addedBy: parseAuthorName(file.user_id),
+    source,
+    productId: context.productId ?? null,
+    dealProductId: context.dealProductId ?? null
+  };
+};
+
+const parseRecommendedHours = (value: unknown): { raw: string | null; hours: number | null } => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return { raw: String(value), hours: value };
+  }
+
+  if (typeof value === 'string') {
+    const raw = value.trim();
+    if (!raw) {
+      return { raw: null, hours: null };
+    }
+
+    const match = raw.match(/(\d+(?:[.,]\d+)?)/);
+
+    if (match) {
+      const parsed = Number.parseFloat(match[1].replace(',', '.'));
+      if (Number.isFinite(parsed)) {
+        return { raw, hours: parsed };
+      }
+    }
+
+    return { raw, hours: null };
+  }
+
+  return { raw: null, hours: null };
+};
+
 const loadSedeOptions = async (): Promise<Map<string, string>> => {
   type FieldOption = { id: number | string; label: string };
   type FieldResponse = { data?: { options?: FieldOption[] } | null };
@@ -87,6 +285,28 @@ const loadSedeOptions = async (): Promise<Map<string, string>> => {
   }
 };
 
+const loadPipelineMap = async (): Promise<Map<number, string>> => {
+  type Pipeline = { id: number; name?: string | null };
+  type PipelinesResponse = { data?: Pipeline[] | null };
+
+  try {
+    const response = await fetchJson<PipelinesResponse>('pipelines', {});
+    const pipelines = response.data ?? [];
+    const map = new Map<number, string>();
+
+    pipelines.forEach((pipeline) => {
+      if (typeof pipeline.id === 'number' && pipeline.name) {
+        map.set(pipeline.id, pipeline.name);
+      }
+    });
+
+    return map;
+  } catch (error) {
+    console.error('No se pudieron cargar los embudos de Pipedrive', error);
+    return new Map<number, string>();
+  }
+};
+
 const extractClient = (deal: PipedriveDeal): { id: number | null; name: string | null } => {
   const org = deal.org_id;
   if (typeof org === 'number') {
@@ -96,7 +316,7 @@ const extractClient = (deal: PipedriveDeal): { id: number | null; name: string |
   if (org && typeof org === 'object') {
     return {
       id: typeof org.value === 'number' ? org.value : null,
-      name: typeof org.name === 'string' ? org.name : deal.org_name ?? null
+      name: typeof (org as { name?: unknown }).name === 'string' ? ((org as { name?: unknown }).name as string) : deal.org_name ?? null
     };
   }
 
@@ -106,19 +326,239 @@ const extractClient = (deal: PipedriveDeal): { id: number | null; name: string |
   };
 };
 
-const fetchDealProducts = async (dealId: number): Promise<string[]> => {
+const fetchDealNotes = async (dealId: number): Promise<NormalisedNote[]> => {
+  type NotesResponse = { data?: PipedriveNote[] | null };
+
+  try {
+    const response = await fetchJson<NotesResponse>(`deals/${dealId}/notes`, {
+      sort_by: 'add_time',
+      sort_direction: 'desc'
+    });
+
+    const notes = response.data ?? [];
+    return notes
+      .map((note) => normaliseNote(note, 'deal'))
+      .filter((note) => note.content.length > 0);
+  } catch (error) {
+    console.error(`No se pudieron obtener las notas del deal ${dealId}`, error);
+    return [];
+  }
+};
+
+const fetchDealFiles = async (dealId: number): Promise<NormalisedAttachment[]> => {
+  type FilesResponse = { data?: PipedriveFile[] | null };
+
+  try {
+    const response = await fetchJson<FilesResponse>(`deals/${dealId}/files`, {
+      sort: 'add_time DESC'
+    });
+
+    const files = response.data ?? [];
+    return files
+      .map((file) => normaliseAttachment(file, 'deal'))
+      .filter((attachment): attachment is NormalisedAttachment => Boolean(attachment));
+  } catch (error) {
+    console.error(`No se pudieron obtener los archivos del deal ${dealId}`, error);
+    return [];
+  }
+};
+
+const fetchProductDetail = async (
+  productId: number,
+  cache: Map<number, PipedriveProduct | null>
+): Promise<PipedriveProduct | null> => {
+  if (cache.has(productId)) {
+    return cache.get(productId) ?? null;
+  }
+
+  type ProductResponse = { data?: PipedriveProduct | null };
+
+  try {
+    const response = await fetchJson<ProductResponse>(`products/${productId}`, {});
+    const product = response.data ?? null;
+    cache.set(productId, product);
+    return product;
+  } catch (error) {
+    console.error(`No se pudo obtener la información del producto ${productId}`, error);
+    cache.set(productId, null);
+    return null;
+  }
+};
+
+const fetchProductNotes = async (
+  productId: number,
+  cache: Map<number, NormalisedNote[]>
+): Promise<NormalisedNote[]> => {
+  if (cache.has(productId)) {
+    return cache.get(productId) ?? [];
+  }
+
+  type NotesResponse = { data?: PipedriveNote[] | null };
+
+  try {
+    const response = await fetchJson<NotesResponse>(`products/${productId}/notes`, {
+      sort_by: 'add_time',
+      sort_direction: 'desc'
+    });
+
+    const notes = (response.data ?? [])
+      .map((note) => normaliseNote(note, 'product', { productId }))
+      .filter((note) => note.content.length > 0);
+
+    cache.set(productId, notes);
+    return notes;
+  } catch (error) {
+    console.error(`No se pudieron obtener las notas del producto ${productId}`, error);
+    cache.set(productId, []);
+    return [];
+  }
+};
+
+const fetchProductFiles = async (
+  productId: number,
+  cache: Map<number, NormalisedAttachment[]>
+): Promise<NormalisedAttachment[]> => {
+  if (cache.has(productId)) {
+    return cache.get(productId) ?? [];
+  }
+
+  type FilesResponse = { data?: PipedriveFile[] | null };
+
+  try {
+    const response = await fetchJson<FilesResponse>(`products/${productId}/files`, {
+      sort: 'add_time DESC'
+    });
+
+    const files = (response.data ?? [])
+      .map((file) => normaliseAttachment(file, 'product', { productId }))
+      .filter((attachment): attachment is NormalisedAttachment => Boolean(attachment));
+
+    cache.set(productId, files);
+    return files;
+  } catch (error) {
+    console.error(`No se pudieron obtener los archivos del producto ${productId}`, error);
+    cache.set(productId, []);
+    return [];
+  }
+};
+
+const fetchDealProductsDetailed = async (
+  dealId: number,
+  caches: {
+    productDetails: Map<number, PipedriveProduct | null>;
+    productNotes: Map<number, NormalisedNote[]>;
+    productFiles: Map<number, NormalisedAttachment[]>;
+  }
+): Promise<NormalisedProduct[]> => {
   type ProductsResponse = { data?: DealProductItem[] | null };
 
   try {
-    const productsResponse = await fetchJson<ProductsResponse>(`deals/${dealId}/products`, {});
+    const productsResponse = await fetchJson<ProductsResponse>(`deals/${dealId}/products`, {
+      include_product_data: 1
+    });
+
     const items = productsResponse.data ?? [];
 
-    return items
-      .map((item) => item.product)
-      .filter((product): product is NonNullable<DealProductItem['product']> => Boolean(product?.name))
-      .filter((product) => (product.code ?? '').toLowerCase().startsWith('form-'))
-      .map((product) => product.name!.trim())
-      .filter((name, index, array) => name.length > 0 && array.indexOf(name) === index);
+    const products = await Promise.all(
+      items.map(async (item) => {
+        const dealProductId = toInteger(item.id);
+
+        if (dealProductId == null) {
+          return null;
+        }
+
+        const rawQuantity = toNumber(item.quantity);
+        const quantity = rawQuantity != null && rawQuantity > 0 ? rawQuantity : 0;
+
+        const rawItemPrice = toNumber(item.item_price);
+        const itemPrice = rawItemPrice != null ? rawItemPrice : null;
+
+        const embeddedProduct = item.product ?? null;
+        const productId =
+          toInteger(item.product_id) ??
+          (embeddedProduct && typeof embeddedProduct.id === 'number' ? embeddedProduct.id : null);
+
+        const candidateNames = [
+          typeof item.name === 'string' ? item.name : null,
+          embeddedProduct && typeof embeddedProduct.name === 'string' ? embeddedProduct.name : null
+        ];
+
+        const name = candidateNames.find((value) => value && value.trim().length > 0)?.trim() ?? 'Producto sin nombre';
+
+        const candidateCodes = [
+          typeof item.code === 'string' ? item.code : null,
+          embeddedProduct && typeof embeddedProduct.code === 'string' ? embeddedProduct.code : null
+        ];
+
+        const code = candidateCodes.find((value) => value && value.trim().length > 0)?.trim() ?? null;
+
+        let recommendedRaw: string | null = null;
+        let recommendedHours: number | null = null;
+
+        const recommendedFromItem = (item as Record<string, unknown>)[RECOMMENDED_HOURS_FIELD_KEY];
+        const parsedFromItem = parseRecommendedHours(recommendedFromItem);
+
+        if (parsedFromItem.raw) {
+          recommendedRaw = parsedFromItem.raw;
+          recommendedHours = parsedFromItem.hours;
+        }
+
+        if (productId != null && (recommendedRaw == null || recommendedHours == null)) {
+          const productDetail = await fetchProductDetail(productId, caches.productDetails);
+
+          if (productDetail) {
+            const fromProduct = parseRecommendedHours((productDetail as Record<string, unknown>)[RECOMMENDED_HOURS_FIELD_KEY]);
+
+            if (fromProduct.raw) {
+              recommendedRaw = fromProduct.raw;
+              recommendedHours = fromProduct.hours;
+            }
+          }
+        }
+
+        if (embeddedProduct && (recommendedRaw == null || recommendedHours == null)) {
+          const fromEmbedded = parseRecommendedHours((embeddedProduct as Record<string, unknown>)[RECOMMENDED_HOURS_FIELD_KEY]);
+
+          if (fromEmbedded.raw) {
+            recommendedRaw = fromEmbedded.raw;
+            recommendedHours = fromEmbedded.hours;
+          }
+        }
+
+        const productNotes = productId != null ? await fetchProductNotes(productId, caches.productNotes) : [];
+        const productFiles = productId != null ? await fetchProductFiles(productId, caches.productFiles) : [];
+
+        const notesWithContext = productNotes.map((note) => ({
+          ...note,
+          dealProductId,
+          productId: note.productId ?? productId
+        }));
+
+        const filesWithContext = productFiles.map((file) => ({
+          ...file,
+          dealProductId,
+          productId: file.productId ?? productId
+        }));
+
+        const isTraining = Boolean((code ?? '').toLowerCase().startsWith(TRAINING_CODE_PREFIX));
+
+        return {
+          dealProductId,
+          productId,
+          name,
+          code,
+          quantity,
+          itemPrice,
+          recommendedHours,
+          recommendedHoursRaw: recommendedRaw,
+          notes: notesWithContext,
+          attachments: filesWithContext,
+          isTraining
+        } satisfies NormalisedProduct;
+      })
+    );
+
+    return products.filter((product): product is NormalisedProduct => Boolean(product));
   } catch (error) {
     console.error(`No se pudieron obtener los productos del deal ${dealId}`, error);
     return [];
@@ -127,12 +567,51 @@ const fetchDealProducts = async (dealId: number): Promise<string[]> => {
 
 const normaliseDeal = async (
   deal: PipedriveDeal,
-  sedeOptions: Map<string, string>
+  sedeOptions: Map<string, string>,
+  pipelineMap: Map<number, string>,
+  caches: {
+    productDetails: Map<number, PipedriveProduct | null>;
+    productNotes: Map<number, NormalisedNote[]>;
+    productFiles: Map<number, NormalisedAttachment[]>;
+  }
 ): Promise<NormalisedDeal> => {
   const client = extractClient(deal);
   const sedeRaw = (deal as Record<string, unknown>)[SEDE_FIELD_KEY];
   const sedeLabel = sedeRaw != null ? sedeOptions.get(String(sedeRaw)) ?? null : null;
-  const formations = await fetchDealProducts(deal.id);
+
+  const addressRaw = (deal as Record<string, unknown>)[ADDRESS_FIELD_KEY];
+  const address = typeof addressRaw === 'string' && addressRaw.trim().length > 0 ? addressRaw.trim() : null;
+
+  const pipelineId = toInteger(deal.pipeline_id);
+  const pipelineName = pipelineId != null ? pipelineMap.get(pipelineId) ?? null : null;
+
+  const [products, dealNotes, dealFiles] = await Promise.all([
+    fetchDealProductsDetailed(deal.id, caches),
+    fetchDealNotes(deal.id),
+    fetchDealFiles(deal.id)
+  ]);
+
+  const trainingProducts = products.filter((product) => product.isTraining);
+  const extraProducts = products.filter((product) => !product.isTraining);
+
+  const productNotes = products.flatMap((product) => product.notes.map((note) => ({
+    ...note,
+    dealProductId: product.dealProductId,
+    productId: note.productId ?? product.productId
+  })));
+
+  const productAttachments = products.flatMap((product) => product.attachments.map((attachment) => ({
+    ...attachment,
+    dealProductId: product.dealProductId,
+    productId: attachment.productId ?? product.productId
+  })));
+
+  const notes = [...dealNotes, ...productNotes];
+  const attachments = [...dealFiles, ...productAttachments];
+
+  const formations = trainingProducts
+    .map((product) => product.name)
+    .filter((name, index, array) => name && array.indexOf(name) === index);
 
   return {
     id: deal.id,
@@ -140,15 +619,23 @@ const normaliseDeal = async (
     clientId: client.id,
     clientName: client.name,
     sede: sedeLabel,
-    formations
+    address,
+    pipelineId,
+    pipelineName,
+    formations,
+    trainingProducts,
+    extraProducts,
+    notes,
+    attachments
   };
 };
 
 const loadDeals = async (stageId: number): Promise<NormalisedDeal[]> => {
   type DealsResponse = { data?: PipedriveDeal[] | null };
 
-  const [sedeOptions, dealsResponse] = await Promise.all([
+  const [sedeOptions, pipelineMap, dealsResponse] = await Promise.all([
     loadSedeOptions(),
+    loadPipelineMap(),
     fetchJson<DealsResponse>('deals', {
       stage_id: stageId,
       limit: 500,
@@ -159,14 +646,21 @@ const loadDeals = async (stageId: number): Promise<NormalisedDeal[]> => {
 
   const deals = dealsResponse.data ?? [];
 
-  return Promise.all(deals.map((deal) => normaliseDeal(deal, sedeOptions)));
+  const caches = {
+    productDetails: new Map<number, PipedriveProduct | null>(),
+    productNotes: new Map<number, NormalisedNote[]>(),
+    productFiles: new Map<number, NormalisedAttachment[]>()
+  };
+
+  return Promise.all(deals.map((deal) => normaliseDeal(deal, sedeOptions, pipelineMap, caches)));
 };
 
 const loadDealById = async (dealId: number): Promise<NormalisedDeal | null> => {
   type DealResponse = { data?: PipedriveDeal | null };
 
-  const [sedeOptions, dealResponse] = await Promise.all([
+  const [sedeOptions, pipelineMap, dealResponse] = await Promise.all([
     loadSedeOptions(),
+    loadPipelineMap(),
     fetchJson<DealResponse>(`deals/${dealId}`, {})
   ]);
 
@@ -175,7 +669,13 @@ const loadDealById = async (dealId: number): Promise<NormalisedDeal | null> => {
     return null;
   }
 
-  return normaliseDeal(deal, sedeOptions);
+  const caches = {
+    productDetails: new Map<number, PipedriveProduct | null>(),
+    productNotes: new Map<number, NormalisedNote[]>(),
+    productFiles: new Map<number, NormalisedAttachment[]>()
+  };
+
+  return normaliseDeal(deal, sedeOptions, pipelineMap, caches);
 };
 
 export const handler: Handler = async (event) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,28 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Container from 'react-bootstrap/Container';
 import Stack from 'react-bootstrap/Stack';
 import CalendarView from './components/calendar/CalendarView';
 import DealsBoard from './components/deals/DealsBoard';
 import HeaderBar from './components/layout/HeaderBar';
+import { CalendarEvent, loadCalendarEvents, persistCalendarEvents } from './services/calendar';
 import './App.scss';
 
 type TabKey = 'calendar' | 'backlog';
 
 const App = () => {
   const [activeTab, setActiveTab] = useState<TabKey>('calendar');
+  const [calendarEvents, setCalendarEvents] = useState<CalendarEvent[]>(() => loadCalendarEvents());
+
+  useEffect(() => {
+    persistCalendarEvents(calendarEvents);
+  }, [calendarEvents]);
+
+  const handleUpdateSchedule = (dealId: number, events: CalendarEvent[]) => {
+    setCalendarEvents((previous) => {
+      const filtered = previous.filter((event) => event.dealId !== dealId);
+      return [...filtered, ...events];
+    });
+  };
 
   return (
     <div className="app-shell">
@@ -17,7 +30,11 @@ const App = () => {
       <main className="app-main">
         <Container fluid className="pt-4 pb-5">
           <Stack gap={4}>
-            {activeTab === 'calendar' ? <CalendarView /> : <DealsBoard />}
+            {activeTab === 'calendar' ? (
+              <CalendarView events={calendarEvents} />
+            ) : (
+              <DealsBoard events={calendarEvents} onUpdateSchedule={handleUpdateSchedule} />
+            )}
           </Stack>
         </Container>
       </main>

--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -5,8 +5,27 @@ import listPlugin from '@fullcalendar/list';
 import interactionPlugin from '@fullcalendar/interaction';
 import esLocale from '@fullcalendar/core/locales/es';
 import Card from 'react-bootstrap/Card';
+import { CalendarEvent } from '../../services/calendar';
 
-const CalendarView = () => (
+interface CalendarViewProps {
+  events: CalendarEvent[];
+}
+
+const buildEventTitle = (event: CalendarEvent) => {
+  const segments = [event.productName];
+
+  if (event.attendees != null) {
+    segments.push(`${event.attendees} alumno${event.attendees === 1 ? '' : 's'}`);
+  }
+
+  if (event.sede) {
+    segments.push(event.sede);
+  }
+
+  return segments.join(' · ');
+};
+
+const CalendarView = ({ events }: CalendarViewProps) => (
   <Card className="calendar-card border-0">
     <Card.Body className="p-0">
       <div className="calendar-scroll-container">
@@ -26,7 +45,20 @@ const CalendarView = () => (
           scrollTime="06:00:00"
           height="parent"
           nowIndicator
-          events={[]}
+          events={events.map((event) => ({
+            id: event.id,
+            title: buildEventTitle(event),
+            start: event.start,
+            end: event.end,
+            extendedProps: {
+              dealId: event.dealId,
+              dealTitle: event.dealTitle,
+              productName: event.productName,
+              attendees: event.attendees,
+              sede: event.sede,
+              address: event.address
+            }
+          }))}
           locales={[esLocale]}
           locale="es"
         />

--- a/src/components/deals/DealDetailModal.tsx
+++ b/src/components/deals/DealDetailModal.tsx
@@ -1,0 +1,1039 @@
+import { useEffect, useMemo, useState } from 'react';
+import Alert from 'react-bootstrap/Alert';
+import Badge from 'react-bootstrap/Badge';
+import Button from 'react-bootstrap/Button';
+import Col from 'react-bootstrap/Col';
+import Form from 'react-bootstrap/Form';
+import ListGroup from 'react-bootstrap/ListGroup';
+import Modal from 'react-bootstrap/Modal';
+import Row from 'react-bootstrap/Row';
+import Stack from 'react-bootstrap/Stack';
+import Table from 'react-bootstrap/Table';
+import { CalendarEvent } from '../../services/calendar';
+import { DealAttachment, DealNote, DealProduct, DealRecord } from '../../services/deals';
+import {
+  loadDealExtras,
+  persistDealExtras,
+  StoredDealDocument,
+  StoredDealNote
+} from '../../services/dealExtras';
+
+interface DealDetailModalProps {
+  show: boolean;
+  deal: DealRecord;
+  events: CalendarEvent[];
+  onHide: () => void;
+  onUpdateSchedule: (dealId: number, events: CalendarEvent[]) => void;
+  onDealRefetch: () => Promise<void> | void;
+}
+
+interface SessionFormEntry {
+  key: string;
+  dealProductId: number;
+  productId: number | null;
+  productName: string;
+  recommendedHours: number | null;
+  recommendedHoursRaw: string | null;
+  sessionIndex: number;
+  start: string;
+  end: string;
+  endTouched: boolean;
+  attendees: string;
+  sede: string;
+  address: string;
+}
+
+type DisplayNote = DealNote;
+type DisplayAttachment = DealAttachment;
+
+const generateId = () =>
+  typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : Math.random().toString(36).slice(2);
+
+const toDateTimeLocalString = (date: Date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
+};
+
+const formatDateTimeInput = (iso: string | null | undefined): string => {
+  if (!iso) {
+    return '';
+  }
+
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+
+  return toDateTimeLocalString(date);
+};
+
+const toIsoString = (value: string): string | null => {
+  if (!value) {
+    return null;
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return date.toISOString();
+};
+
+const computeEndFromStart = (start: string, hours: number | null): string => {
+  if (!start || hours == null) {
+    return '';
+  }
+
+  const date = new Date(start);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+
+  const milliseconds = hours * 60 * 60 * 1000;
+  date.setTime(date.getTime() + milliseconds);
+  return toDateTimeLocalString(date);
+};
+
+const formatDateLabel = (iso: string | null) => {
+  if (!iso) {
+    return 'Sin fecha';
+  }
+
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return 'Sin fecha';
+  }
+
+  return date.toLocaleString();
+};
+
+const resolveProductName = (
+  dealProductId: number | null,
+  productId: number | null,
+  productMapByDealId: Map<number, string>,
+  productMapByProductId: Map<number, string>
+) => {
+  if (dealProductId != null && productMapByDealId.has(dealProductId)) {
+    return productMapByDealId.get(dealProductId) ?? null;
+  }
+
+  if (productId != null && productMapByProductId.has(productId)) {
+    return productMapByProductId.get(productId) ?? null;
+  }
+
+  return null;
+};
+
+const countSessionsForProduct = (product: DealProduct) => {
+  const quantity = Math.round(product.quantity);
+  return quantity > 0 ? quantity : 1;
+};
+
+const DealDetailModal = ({
+  show,
+  deal,
+  events,
+  onHide,
+  onUpdateSchedule,
+  onDealRefetch
+}: DealDetailModalProps) => {
+  const [localNotes, setLocalNotes] = useState<StoredDealNote[]>([]);
+  const [localDocuments, setLocalDocuments] = useState<StoredDealDocument[]>([]);
+  const [showNoteModal, setShowNoteModal] = useState(false);
+  const [noteText, setNoteText] = useState('');
+  const [noteTarget, setNoteTarget] = useState('general');
+  const [noteError, setNoteError] = useState<string | null>(null);
+  const [showDocumentModal, setShowDocumentModal] = useState(false);
+  const [documentName, setDocumentName] = useState('');
+  const [documentUrl, setDocumentUrl] = useState('');
+  const [documentTarget, setDocumentTarget] = useState('general');
+  const [documentError, setDocumentError] = useState<string | null>(null);
+  const [saveFeedback, setSaveFeedback] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [mapVisible, setMapVisible] = useState(false);
+
+  const productMap = useMemo(() => {
+    const byDealProductId = new Map<number, string>();
+    const byProductId = new Map<number, string>();
+
+    [...deal.trainingProducts, ...deal.extraProducts].forEach((product) => {
+      byDealProductId.set(product.dealProductId, product.name);
+      if (product.productId != null) {
+        byProductId.set(product.productId, product.name);
+      }
+    });
+
+    return { byDealProductId, byProductId };
+  }, [deal.extraProducts, deal.trainingProducts]);
+
+  useEffect(() => {
+    const extras = loadDealExtras(deal.id);
+    setLocalNotes(extras.notes ?? []);
+    setLocalDocuments(extras.documents ?? []);
+    setNoteText('');
+    setDocumentName('');
+    setDocumentUrl('');
+    setNoteTarget('general');
+    setDocumentTarget('general');
+    setSaveFeedback(null);
+    setSaveError(null);
+  }, [deal.id]);
+
+  const eventsByKey = useMemo(() => {
+    const map = new Map<string, CalendarEvent>();
+    events
+      .filter((eventItem) => eventItem.dealId === deal.id)
+      .forEach((eventItem) => {
+        const key = `${eventItem.dealProductId}-${eventItem.sessionIndex}`;
+        map.set(key, eventItem);
+      });
+    return map;
+  }, [deal.id, events]);
+
+  const initialSessions = useMemo(() => {
+    return deal.trainingProducts.flatMap((product) => {
+      const sessionsCount = countSessionsForProduct(product);
+      return Array.from({ length: sessionsCount }).map((_, index) => {
+        const key = `${product.dealProductId}-${index}`;
+        const existingEvent = eventsByKey.get(key);
+
+        return {
+          key,
+          dealProductId: product.dealProductId,
+          productId: product.productId,
+          productName: product.name,
+          recommendedHours: product.recommendedHours,
+          recommendedHoursRaw: product.recommendedHoursRaw,
+          sessionIndex: index,
+          start: formatDateTimeInput(existingEvent?.start),
+          end: formatDateTimeInput(existingEvent?.end),
+          endTouched: Boolean(existingEvent?.end),
+          attendees:
+            existingEvent && existingEvent.attendees != null ? String(existingEvent.attendees) : '',
+          sede: existingEvent?.sede ?? deal.sede ?? '',
+          address: existingEvent?.address ?? deal.address ?? ''
+        } satisfies SessionFormEntry;
+      });
+    });
+  }, [deal.address, deal.sede, deal.trainingProducts, eventsByKey]);
+
+  const [sessions, setSessions] = useState<SessionFormEntry[]>(initialSessions);
+
+  useEffect(() => {
+    setSessions(initialSessions);
+  }, [initialSessions, show]);
+
+  const localNoteEntries: DisplayNote[] = useMemo(
+    () =>
+      localNotes.map((note) => ({
+        id: note.id,
+        content: note.content,
+        createdAt: note.createdAt,
+        authorName: 'Equipo de planificación',
+        source: 'local',
+        productId: note.productId ?? null,
+        dealProductId: note.dealProductId ?? null
+      })),
+    [localNotes]
+  );
+
+  const combinedNotes: DisplayNote[] = useMemo(() => {
+    const joined = [...deal.notes, ...localNoteEntries];
+    return joined.sort((a, b) => {
+      const left = a.createdAt ?? '';
+      const right = b.createdAt ?? '';
+      return right.localeCompare(left);
+    });
+  }, [deal.notes, localNoteEntries]);
+
+  const localAttachmentEntries: DisplayAttachment[] = useMemo(
+    () =>
+      localDocuments.map((document) => ({
+        id: document.id,
+        name: document.name,
+        url: document.url,
+        downloadUrl: document.url,
+        fileType: null,
+        addedAt: document.createdAt,
+        addedBy: 'Equipo de planificación',
+        source: 'local',
+        productId: document.productId ?? null,
+        dealProductId: document.dealProductId ?? null
+      })),
+    [localDocuments]
+  );
+
+  const combinedAttachments: DisplayAttachment[] = useMemo(() => {
+    const joined = [...deal.attachments, ...localAttachmentEntries];
+    return joined.sort((a, b) => {
+      const left = a.addedAt ?? '';
+      const right = b.addedAt ?? '';
+      return right.localeCompare(left);
+    });
+  }, [deal.attachments, localAttachmentEntries]);
+
+  const totalSessions = useMemo(
+    () => deal.trainingProducts.reduce((acc, product) => acc + countSessionsForProduct(product), 0),
+    [deal.trainingProducts]
+  );
+
+  const handleSessionStartChange = (key: string, value: string) => {
+    setSessions((previous) =>
+      previous.map((session) => {
+        if (session.key !== key) {
+          return session;
+        }
+
+        const updated: SessionFormEntry = {
+          ...session,
+          start: value
+        };
+
+        if (!session.endTouched) {
+          const computed = computeEndFromStart(value, session.recommendedHours);
+          if (computed) {
+            updated.end = computed;
+          }
+        }
+
+        return updated;
+      })
+    );
+  };
+
+  const handleSessionEndChange = (key: string, value: string) => {
+    setSessions((previous) =>
+      previous.map((session) =>
+        session.key === key
+          ? {
+              ...session,
+              end: value,
+              endTouched: value.trim().length > 0
+            }
+          : session
+      )
+    );
+  };
+
+  const handleSessionFieldChange = (key: string, field: keyof SessionFormEntry, value: string) => {
+    setSessions((previous) =>
+      previous.map((session) =>
+        session.key === key
+          ? {
+              ...session,
+              [field]: value
+            }
+          : session
+      )
+    );
+  };
+
+  const persistExtras = (notes: StoredDealNote[], documents: StoredDealDocument[]) => {
+    persistDealExtras(deal.id, { notes, documents });
+  };
+
+  const handleSaveSchedule = () => {
+    setSaveError(null);
+    setSaveFeedback(null);
+
+    if (sessions.length === 0) {
+      setSaveError('No hay productos de formación disponibles para calendarizar.');
+      return;
+    }
+
+    const incomplete = sessions.filter((session) => !session.start || !session.end);
+
+    if (incomplete.length > 0) {
+      setSaveError('Todas las sesiones deben tener fecha y hora de inicio y fin.');
+      return;
+    }
+
+    const eventsToSave: CalendarEvent[] = [];
+
+    for (const session of sessions) {
+      const startIso = toIsoString(session.start);
+      const endIso = toIsoString(session.end);
+
+      if (!startIso || !endIso) {
+        setSaveError('Las fechas introducidas no son válidas.');
+        return;
+      }
+
+      const attendeesValue = Number.parseInt(session.attendees, 10);
+      const attendees = Number.isFinite(attendeesValue) ? attendeesValue : null;
+
+      eventsToSave.push({
+        id: `deal-${deal.id}-item-${session.dealProductId}-session-${session.sessionIndex}`,
+        dealId: deal.id,
+        dealTitle: deal.title,
+        dealProductId: session.dealProductId,
+        productId: session.productId,
+        productName: session.productName,
+        sessionIndex: session.sessionIndex,
+        start: startIso,
+        end: endIso,
+        attendees,
+        sede: session.sede.trim() ? session.sede.trim() : null,
+        address: session.address.trim() ? session.address.trim() : null
+      });
+    }
+
+    onUpdateSchedule(deal.id, eventsToSave);
+    setSaveFeedback('La calendarización se guardó correctamente.');
+  };
+
+  const productOptions = useMemo(() => {
+    const options = [...deal.trainingProducts, ...deal.extraProducts];
+    return options.map((product) => ({
+      label: product.name,
+      value: `product-${product.dealProductId}`,
+      dealProductId: product.dealProductId,
+      productId: product.productId ?? null
+    }));
+  }, [deal.extraProducts, deal.trainingProducts]);
+
+  const handleAddNote = () => {
+    const trimmed = noteText.trim();
+
+    if (!trimmed) {
+      setNoteError('La nota no puede estar vacía.');
+      return;
+    }
+
+    const now = new Date().toISOString();
+    let dealProductId: number | undefined;
+    let productId: number | undefined;
+    let productName: string | undefined;
+
+    if (noteTarget.startsWith('product-')) {
+      const identifier = Number.parseInt(noteTarget.replace('product-', ''), 10);
+      const matched = productOptions.find((option) => option.dealProductId === identifier);
+      if (matched) {
+        dealProductId = matched.dealProductId;
+        productId = matched.productId ?? undefined;
+        productName = matched.label;
+      }
+    }
+
+    const note: StoredDealNote = {
+      id: generateId(),
+      content: trimmed,
+      createdAt: now,
+      dealProductId,
+      productId,
+      productName
+    };
+
+    const updatedNotes = [...localNotes, note];
+    setLocalNotes(updatedNotes);
+    persistExtras(updatedNotes, localDocuments);
+    setShowNoteModal(false);
+    setNoteText('');
+    setNoteTarget('general');
+    setNoteError(null);
+  };
+
+  const handleAddDocument = () => {
+    const trimmedName = documentName.trim();
+    const trimmedUrl = documentUrl.trim();
+
+    if (!trimmedName) {
+      setDocumentError('Introduce un nombre para el documento.');
+      return;
+    }
+
+    try {
+      const parsedUrl = new URL(trimmedUrl);
+      if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+        throw new Error('Invalid protocol');
+      }
+    } catch (error) {
+      setDocumentError('Introduce una URL válida.');
+      return;
+    }
+
+    const now = new Date().toISOString();
+    let dealProductId: number | undefined;
+    let productId: number | undefined;
+    let productName: string | undefined;
+
+    if (documentTarget.startsWith('product-')) {
+      const identifier = Number.parseInt(documentTarget.replace('product-', ''), 10);
+      const matched = productOptions.find((option) => option.dealProductId === identifier);
+      if (matched) {
+        dealProductId = matched.dealProductId;
+        productId = matched.productId ?? undefined;
+        productName = matched.label;
+      }
+    }
+
+    const document: StoredDealDocument = {
+      id: generateId(),
+      name: trimmedName,
+      url: trimmedUrl,
+      createdAt: now,
+      dealProductId,
+      productId,
+      productName
+    };
+
+    const updatedDocuments = [...localDocuments, document];
+    setLocalDocuments(updatedDocuments);
+    persistExtras(localNotes, updatedDocuments);
+    setShowDocumentModal(false);
+    setDocumentName('');
+    setDocumentUrl('');
+    setDocumentTarget('general');
+    setDocumentError(null);
+  };
+
+  const handleRefresh = async () => {
+    try {
+      setIsRefreshing(true);
+      await onDealRefetch();
+      setSaveError(null);
+      setSaveFeedback('Datos actualizados desde Pipedrive.');
+    } catch (error) {
+      console.error('No se pudo refrescar el deal', error);
+      setSaveError('No se pudieron actualizar los datos desde Pipedrive.');
+    } finally {
+      setIsRefreshing(false);
+    }
+  };
+
+  const renderNoteOrigin = (note: DisplayNote) => {
+    if (note.source === 'deal') {
+      return 'Deal';
+    }
+
+    const productName = resolveProductName(
+      note.dealProductId,
+      note.productId,
+      productMap.byDealProductId,
+      productMap.byProductId
+    );
+
+    if (note.source === 'local') {
+      return productName ? `ERP · ${productName}` : 'ERP';
+    }
+
+    if (productName) {
+      return `Producto · ${productName}`;
+    }
+
+    return 'Producto';
+  };
+
+  const renderAttachmentOrigin = (attachment: DisplayAttachment) => {
+    if (attachment.source === 'deal') {
+      return 'Deal';
+    }
+
+    const productName = resolveProductName(
+      attachment.dealProductId,
+      attachment.productId,
+      productMap.byDealProductId,
+      productMap.byProductId
+    );
+
+    if (attachment.source === 'local') {
+      return productName ? `ERP · ${productName}` : 'ERP';
+    }
+
+    if (productName) {
+      return `Producto · ${productName}`;
+    }
+
+    return 'Producto';
+  };
+
+  return (
+    <>
+      <Modal show={show} onHide={onHide} size="xl" backdrop="static" fullscreen="md-down">
+        <Modal.Header closeButton>
+          <div>
+            <Modal.Title>Presupuesto #{deal.id}</Modal.Title>
+            <div className="text-muted small">{deal.title}</div>
+          </div>
+        </Modal.Header>
+        <Modal.Body>
+          <Stack gap={4}>
+            <div>
+              <div className="d-flex justify-content-between align-items-center mb-3">
+                <h5 className="mb-0">Datos generales</h5>
+                <Button variant="outline-secondary" size="sm" onClick={handleRefresh} disabled={isRefreshing}>
+                  {isRefreshing ? 'Actualizando…' : 'Actualizar desde Pipedrive'}
+                </Button>
+              </div>
+              <Row className="g-3">
+                <Col lg={4} md={6}>
+                  <div className="border rounded p-3 h-100">
+                    <div className="text-uppercase text-muted small mb-1">Número de presupuesto</div>
+                    <div className="fw-semibold">#{deal.id}</div>
+                  </div>
+                </Col>
+                <Col lg={4} md={6}>
+                  <div className="border rounded p-3 h-100">
+                    <div className="text-uppercase text-muted small mb-1">Cliente</div>
+                    <div className="fw-semibold">
+                      {deal.clientName ?? 'Sin organización asociada'}
+                      {deal.clientId ? <span className="text-muted"> · #{deal.clientId}</span> : null}
+                    </div>
+                  </div>
+                </Col>
+                <Col lg={4} md={6}>
+                  <div className="border rounded p-3 h-100">
+                    <div className="text-uppercase text-muted small mb-1">Tipo de formación</div>
+                    <div className="fw-semibold">{deal.pipelineName ?? 'Sin embudo definido'}</div>
+                  </div>
+                </Col>
+                <Col lg={6} md={6}>
+                  <div className="border rounded p-3 h-100">
+                    <div className="text-uppercase text-muted small mb-1">Formación</div>
+                    {deal.trainingProducts.length > 0 ? (
+                      <Stack direction="horizontal" className="flex-wrap" gap={2}>
+                        {deal.trainingProducts.map((product) => (
+                          <Badge key={product.dealProductId} bg="info" text="dark" className="px-3 py-2 rounded-pill">
+                            {product.name}
+                          </Badge>
+                        ))}
+                      </Stack>
+                    ) : (
+                      <div className="text-muted">Sin productos form-</div>
+                    )}
+                  </div>
+                </Col>
+                <Col lg={3} md={6}>
+                  <div className="border rounded p-3 h-100">
+                    <div className="text-uppercase text-muted small mb-1">Número de sesiones</div>
+                    <div className="fw-semibold">{totalSessions}</div>
+                  </div>
+                </Col>
+                <Col lg={3} md={6}>
+                  <div className="border rounded p-3 h-100">
+                    <div className="text-uppercase text-muted small mb-1">Sede</div>
+                    <div className="fw-semibold">{deal.sede ?? 'Sin sede'}</div>
+                  </div>
+                </Col>
+                <Col lg={6} md={6}>
+                  <div className="border rounded p-3 h-100">
+                    <div className="text-uppercase text-muted small mb-1">Dirección de la formación</div>
+                    {deal.address ? (
+                      <Button variant="link" className="px-0" onClick={() => setMapVisible(true)}>
+                        {deal.address}
+                      </Button>
+                    ) : (
+                      <div className="text-muted">Sin dirección definida</div>
+                    )}
+                  </div>
+                </Col>
+                <Col lg={6} md={6}>
+                  <div className="border rounded p-3 h-100">
+                    <div className="text-uppercase text-muted small mb-1">Horas recomendadas</div>
+                    {deal.trainingProducts.length > 0 ? (
+                      <ul className="mb-0 ps-3">
+                        {deal.trainingProducts.map((product) => (
+                          <li key={`hours-${product.dealProductId}`}>
+                            <span className="fw-semibold">{product.name}:</span>{' '}
+                            {product.recommendedHoursRaw ?? 'Sin información'}
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <div className="text-muted">Sin información disponible</div>
+                    )}
+                  </div>
+                </Col>
+              </Row>
+            </div>
+
+            <div>
+              <h5 className="mb-3">Extras</h5>
+              <Row className="g-3">
+                <Col lg={6}>
+                  <div className="border rounded p-3 h-100">
+                    <div className="d-flex justify-content-between align-items-center mb-3">
+                      <div>
+                        <div className="text-uppercase text-muted small">Notas</div>
+                        <div className="fw-semibold">Seguimiento</div>
+                      </div>
+                      <Button variant="outline-primary" size="sm" onClick={() => setShowNoteModal(true)}>
+                        Añadir nota
+                      </Button>
+                    </div>
+                    {combinedNotes.length > 0 ? (
+                      <ListGroup variant="flush" className="border rounded">
+                        {combinedNotes.map((note) => (
+                          <ListGroup.Item key={note.id} className="py-3">
+                            <div className="fw-semibold mb-1">{note.content || 'Sin contenido'}</div>
+                            <div className="small text-muted d-flex flex-wrap gap-3">
+                              <span>{renderNoteOrigin(note)}</span>
+                              {note.authorName ? <span>Autor: {note.authorName}</span> : null}
+                              {note.createdAt ? <span>{formatDateLabel(note.createdAt)}</span> : null}
+                            </div>
+                          </ListGroup.Item>
+                        ))}
+                      </ListGroup>
+                    ) : (
+                      <div className="text-muted">Sin notas registradas.</div>
+                    )}
+                  </div>
+                </Col>
+                <Col lg={6}>
+                  <div className="border rounded p-3 h-100">
+                    <div className="d-flex justify-content-between align-items-center mb-3">
+                      <div>
+                        <div className="text-uppercase text-muted small">Adjuntos</div>
+                        <div className="fw-semibold">Documentación</div>
+                      </div>
+                      <Button variant="outline-primary" size="sm" onClick={() => setShowDocumentModal(true)}>
+                        Añadir documento
+                      </Button>
+                    </div>
+                    {combinedAttachments.length > 0 ? (
+                      <Table size="sm" responsive className="mb-0">
+                        <thead>
+                          <tr>
+                            <th>Documento</th>
+                            <th>Origen</th>
+                            <th className="text-end">Acciones</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {combinedAttachments.map((attachment) => (
+                            <tr key={attachment.id}>
+                              <td>
+                                <div className="fw-semibold">{attachment.name}</div>
+                                {attachment.addedAt ? (
+                                  <div className="small text-muted">{formatDateLabel(attachment.addedAt)}</div>
+                                ) : null}
+                              </td>
+                              <td className="text-muted">{renderAttachmentOrigin(attachment)}</td>
+                              <td className="text-end">
+                                <Stack direction="horizontal" gap={2} className="justify-content-end">
+                                  <Button
+                                    as="a"
+                                    variant="link"
+                                    size="sm"
+                                    href={attachment.url}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                  >
+                                    Ver
+                                  </Button>
+                                  <Button
+                                    as="a"
+                                    variant="link"
+                                    size="sm"
+                                    href={attachment.downloadUrl ?? attachment.url}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                  >
+                                    Descargar
+                                  </Button>
+                                </Stack>
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </Table>
+                    ) : (
+                      <div className="text-muted">Sin archivos disponibles.</div>
+                    )}
+                  </div>
+                </Col>
+                <Col lg={12}>
+                  <div className="border rounded p-3">
+                    <div className="text-uppercase text-muted small mb-2">Productos extras</div>
+                    {deal.extraProducts.length > 0 ? (
+                      <Table responsive size="sm" className="mb-0">
+                        <thead>
+                          <tr>
+                            <th>Producto</th>
+                            <th>Código</th>
+                            <th>Cantidad</th>
+                            <th>Notas</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {deal.extraProducts.map((product) => (
+                            <tr key={`extra-${product.dealProductId}`}>
+                              <td>{product.name}</td>
+                              <td>{product.code ?? '—'}</td>
+                              <td>{product.quantity}</td>
+                              <td>
+                                {product.notes.length > 0 ? (
+                                  <ul className="mb-0 ps-3">
+                                    {product.notes.map((note) => (
+                                      <li key={`extra-note-${note.id}`}>{note.content}</li>
+                                    ))}
+                                  </ul>
+                                ) : (
+                                  <span className="text-muted">Sin notas</span>
+                                )}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </Table>
+                    ) : (
+                      <div className="text-muted">No hay productos extras registrados.</div>
+                    )}
+                  </div>
+                </Col>
+              </Row>
+            </div>
+
+            <div>
+              <h5 className="mb-3">Calendarización</h5>
+              {saveFeedback && (
+                <Alert variant="success" onClose={() => setSaveFeedback(null)} dismissible>
+                  {saveFeedback}
+                </Alert>
+              )}
+              {saveError && (
+                <Alert variant="danger" onClose={() => setSaveError(null)} dismissible>
+                  {saveError}
+                </Alert>
+              )}
+
+              {deal.trainingProducts.length === 0 ? (
+                <div className="text-muted">No hay productos de formación disponibles para calendarizar.</div>
+              ) : (
+                <Stack gap={3}>
+                  {deal.trainingProducts.map((product) => {
+                    const productSessions = sessions.filter((session) => session.dealProductId === product.dealProductId);
+                    const sessionCount = countSessionsForProduct(product);
+                    return (
+                      <div key={`calendar-${product.dealProductId}`} className="border rounded p-3">
+                        <div className="d-flex justify-content-between align-items-center mb-3">
+                          <div>
+                            <div className="fw-semibold">{product.name}</div>
+                            <div className="text-muted small">
+                              {sessionCount} sesión{sessionCount === 1 ? '' : 'es'} ·{' '}
+                              {product.recommendedHoursRaw ?? 'Horas recomendadas no disponibles'}
+                            </div>
+                          </div>
+                        </div>
+                        <Stack gap={3}>
+                          {productSessions.map((session) => (
+                            <div key={session.key} className="border rounded p-3 bg-light">
+                              <div className="fw-semibold mb-3">Sesión {session.sessionIndex + 1}</div>
+                              <Row className="g-3">
+                                <Col lg={3} md={6}>
+                                  <Form.Group controlId={`start-${session.key}`}>
+                                    <Form.Label>Hora y fecha inicio</Form.Label>
+                                    <Form.Control
+                                      type="datetime-local"
+                                      value={session.start}
+                                      onChange={(event) => handleSessionStartChange(session.key, event.target.value)}
+                                    />
+                                  </Form.Group>
+                                </Col>
+                                <Col lg={3} md={6}>
+                                  <Form.Group controlId={`end-${session.key}`}>
+                                    <Form.Label>Hora y fecha fin</Form.Label>
+                                    <Form.Control
+                                      type="datetime-local"
+                                      value={session.end}
+                                      onChange={(event) => handleSessionEndChange(session.key, event.target.value)}
+                                    />
+                                  </Form.Group>
+                                </Col>
+                                <Col lg={2} md={6}>
+                                  <Form.Group controlId={`attendees-${session.key}`}>
+                                    <Form.Label>Alumnos</Form.Label>
+                                    <Form.Control
+                                      type="number"
+                                      min={0}
+                                      value={session.attendees}
+                                      onChange={(event) => handleSessionFieldChange(session.key, 'attendees', event.target.value)}
+                                    />
+                                  </Form.Group>
+                                </Col>
+                                <Col lg={2} md={6}>
+                                  <Form.Group controlId={`sede-${session.key}`}>
+                                    <Form.Label>Sede</Form.Label>
+                                    <Form.Control
+                                      type="text"
+                                      value={session.sede}
+                                      onChange={(event) => handleSessionFieldChange(session.key, 'sede', event.target.value)}
+                                    />
+                                  </Form.Group>
+                                </Col>
+                                <Col lg={4} md={12}>
+                                  <Form.Group controlId={`address-${session.key}`}>
+                                    <Form.Label>Dirección de la formación</Form.Label>
+                                    <Form.Control
+                                      type="text"
+                                      value={session.address}
+                                      onChange={(event) => handleSessionFieldChange(session.key, 'address', event.target.value)}
+                                    />
+                                  </Form.Group>
+                                </Col>
+                              </Row>
+                            </div>
+                          ))}
+                        </Stack>
+                      </div>
+                    );
+                  })}
+                </Stack>
+              )}
+            </div>
+          </Stack>
+        </Modal.Body>
+        <Modal.Footer className="justify-content-between">
+          <div className="text-muted small">
+            Los cambios se guardan en el calendario interno de planificación.
+          </div>
+          <div className="d-flex gap-2">
+            <Button variant="secondary" onClick={onHide}>
+              Cerrar
+            </Button>
+            <Button variant="primary" onClick={handleSaveSchedule} disabled={deal.trainingProducts.length === 0}>
+              Guardar en calendario
+            </Button>
+          </div>
+        </Modal.Footer>
+      </Modal>
+
+      <Modal show={showNoteModal} onHide={() => setShowNoteModal(false)} centered>
+        <Modal.Header closeButton>
+          <Modal.Title>Añadir nota</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          {noteError && (
+            <Alert variant="danger" onClose={() => setNoteError(null)} dismissible>
+              {noteError}
+            </Alert>
+          )}
+          <Stack gap={3}>
+            <Form.Group controlId="note-content">
+              <Form.Label>Contenido</Form.Label>
+              <Form.Control
+                as="textarea"
+                rows={4}
+                value={noteText}
+                onChange={(event) => setNoteText(event.target.value)}
+                placeholder="Añade aquí la nota para el equipo de planificación"
+              />
+            </Form.Group>
+            <Form.Group controlId="note-target">
+              <Form.Label>Asociar a</Form.Label>
+              <Form.Select value={noteTarget} onChange={(event) => setNoteTarget(event.target.value)}>
+                <option value="general">General</option>
+                {productOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </Form.Select>
+            </Form.Group>
+          </Stack>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={() => setShowNoteModal(false)}>
+            Cancelar
+          </Button>
+          <Button variant="primary" onClick={handleAddNote}>
+            Guardar nota
+          </Button>
+        </Modal.Footer>
+      </Modal>
+
+      <Modal show={showDocumentModal} onHide={() => setShowDocumentModal(false)} centered>
+        <Modal.Header closeButton>
+          <Modal.Title>Añadir documento</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          {documentError && (
+            <Alert variant="danger" onClose={() => setDocumentError(null)} dismissible>
+              {documentError}
+            </Alert>
+          )}
+          <Stack gap={3}>
+            <Form.Group controlId="document-name">
+              <Form.Label>Nombre</Form.Label>
+              <Form.Control
+                type="text"
+                value={documentName}
+                onChange={(event) => setDocumentName(event.target.value)}
+                placeholder="Ej. Programa del curso"
+              />
+            </Form.Group>
+            <Form.Group controlId="document-url">
+              <Form.Label>URL</Form.Label>
+              <Form.Control
+                type="url"
+                value={documentUrl}
+                onChange={(event) => setDocumentUrl(event.target.value)}
+                placeholder="https://..."
+              />
+            </Form.Group>
+            <Form.Group controlId="document-target">
+              <Form.Label>Asociar a</Form.Label>
+              <Form.Select value={documentTarget} onChange={(event) => setDocumentTarget(event.target.value)}>
+                <option value="general">General</option>
+                {productOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </Form.Select>
+            </Form.Group>
+          </Stack>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={() => setShowDocumentModal(false)}>
+            Cancelar
+          </Button>
+          <Button variant="primary" onClick={handleAddDocument}>
+            Guardar documento
+          </Button>
+        </Modal.Footer>
+      </Modal>
+
+      <Modal show={mapVisible} onHide={() => setMapVisible(false)} size="lg" centered>
+        <Modal.Header closeButton>
+          <Modal.Title>Ubicación de la formación</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          {deal.address ? (
+            <div className="ratio ratio-16x9">
+              <iframe
+                title="Ubicación"
+                src={`https://www.google.com/maps?q=${encodeURIComponent(deal.address)}&output=embed`}
+                allowFullScreen
+              />
+            </div>
+          ) : (
+            <div className="text-muted">No se ha definido una dirección.</div>
+          )}
+        </Modal.Body>
+        <Modal.Footer>
+          <Button
+            as="a"
+            href={deal.address ? `https://www.google.com/maps?q=${encodeURIComponent(deal.address)}` : '#'}
+            target="_blank"
+            rel="noopener noreferrer"
+            variant="primary"
+            disabled={!deal.address}
+          >
+            Abrir en Google Maps
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+};
+
+export default DealDetailModal;

--- a/src/components/deals/DealsBoard.tsx
+++ b/src/components/deals/DealsBoard.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import Alert from 'react-bootstrap/Alert';
 import Badge from 'react-bootstrap/Badge';
 import Button from 'react-bootstrap/Button';
@@ -7,35 +7,31 @@ import Card from 'react-bootstrap/Card';
 import Placeholder from 'react-bootstrap/Placeholder';
 import Stack from 'react-bootstrap/Stack';
 import Table from 'react-bootstrap/Table';
+import { CalendarEvent } from '../../services/calendar';
 import { fetchDealById, fetchDeals, DealRecord } from '../../services/deals';
+import DealDetailModal from './DealDetailModal';
 
-const renderRow = (deal: DealRecord) => (
-  <tr key={deal.id}>
-    <td className="fw-semibold text-primary">#{deal.id}</td>
-    <td>{deal.title}</td>
-    <td>{deal.clientName ?? 'Sin organización asociada'}</td>
-    <td>{deal.sede ?? 'Sin sede definida'}</td>
-    <td className="text-nowrap">
-      {deal.formations.length > 0 ? (
-        <Stack direction="horizontal" gap={2} className="flex-wrap">
-          {deal.formations.map((name) => (
-            <Badge key={name} bg="info" text="dark" className="px-3 py-2 rounded-pill">
-              {name}
-            </Badge>
-          ))}
-        </Stack>
-      ) : (
-        <span className="text-muted">Sin formaciones form-</span>
-      )}
-    </td>
+const skeletonRows = Array.from({ length: 4 }, (_, index) => (
+  <tr key={`skeleton-${index}`}>
+    {Array.from({ length: 5 }).map((__, cell) => (
+      <td key={cell}>
+        <Placeholder animation="wave" xs={12} className="rounded-pill" />
+      </td>
+    ))}
   </tr>
-);
+));
 
 type FeedbackState = { type: 'success' | 'error'; message: string } | null;
 
-const DealsBoard = () => {
+interface DealsBoardProps {
+  events: CalendarEvent[];
+  onUpdateSchedule: (dealId: number, events: CalendarEvent[]) => void;
+}
+
+const DealsBoard = ({ events, onUpdateSchedule }: DealsBoardProps) => {
   const queryClient = useQueryClient();
   const [feedback, setFeedback] = useState<FeedbackState>(null);
+  const [selectedDealId, setSelectedDealId] = useState<number | null>(null);
   const { data, isLoading, isError, error, refetch, isFetching } = useQuery({
     queryKey: ['deals', 'stage-3'],
     queryFn: fetchDeals,
@@ -94,82 +90,132 @@ const DealsBoard = () => {
     }
   };
 
+  const handleSelectDeal = (dealId: number) => {
+    setSelectedDealId(dealId);
+  };
+
+  const handleCloseModal = () => {
+    setSelectedDealId(null);
+  };
+
+  const selectedDeal = useMemo(() => {
+    if (!selectedDealId || !data) {
+      return null;
+    }
+
+    return data.find((deal) => deal.id === selectedDealId) ?? null;
+  }, [data, selectedDealId]);
+
   return (
-    <Card className="deals-card border-0" role="region" aria-live="polite">
-      <Card.Body>
-        <div className="d-flex justify-content-end mb-4">
-          <Stack direction="horizontal" gap={2}>
-            <Button variant="primary" onClick={handleUploadDeal} disabled={uploadDeal.isPending}>
-              {uploadDeal.isPending ? 'Subiendo…' : 'Subir Deal'}
-            </Button>
-            <Button
-              variant="outline-primary"
-              onClick={() => refetch()}
-              disabled={isFetching && !isLoading}
+    <>
+      <Card className="deals-card border-0" role="region" aria-live="polite">
+        <Card.Body>
+          <div className="d-flex justify-content-end mb-4">
+            <Stack direction="horizontal" gap={2}>
+              <Button variant="primary" onClick={handleUploadDeal} disabled={uploadDeal.isPending}>
+                {uploadDeal.isPending ? 'Subiendo…' : 'Subir Deal'}
+              </Button>
+              <Button variant="outline-primary" onClick={() => refetch()} disabled={isFetching && !isLoading}>
+                {isFetching && !isLoading ? 'Recargando…' : 'Recargar datos'}
+              </Button>
+            </Stack>
+          </div>
+
+          {feedback && (
+            <Alert
+              variant={feedback.type === 'success' ? 'success' : 'danger'}
+              dismissible
+              onClose={() => setFeedback(null)}
+              className="mb-4"
+              role="alert"
             >
-              {isFetching && !isLoading ? 'Recargando…' : 'Recargar datos'}
-            </Button>
-          </Stack>
-        </div>
+              {feedback.message}
+            </Alert>
+          )}
 
-        {feedback && (
-          <Alert
-            variant={feedback.type === 'success' ? 'success' : 'danger'}
-            dismissible
-            onClose={() => setFeedback(null)}
-            className="mb-4"
-            role="alert"
-          >
-            {feedback.message}
-          </Alert>
-        )}
+          {isError && (
+            <Alert variant="danger" className="mb-4" role="alert">
+              Ocurrió un error al sincronizar los presupuestos.
+              <div className="small text-muted">{error instanceof Error ? error.message : 'Intenta de nuevo más tarde.'}</div>
+            </Alert>
+          )}
 
-        {isError && (
-          <Alert variant="danger" className="mb-4" role="alert">
-            Ocurrió un error al sincronizar los presupuestos.
-            <div className="small text-muted">{error instanceof Error ? error.message : 'Intenta de nuevo más tarde.'}</div>
-          </Alert>
-        )}
+          <div className="table-responsive">
+            <Table hover className="align-middle mb-0">
+              <thead>
+                <tr>
+                  <th scope="col">Presupuesto</th>
+                  <th scope="col">Título</th>
+                  <th scope="col">Cliente</th>
+                  <th scope="col">Sede</th>
+                  <th scope="col">Formación</th>
+                </tr>
+              </thead>
+              <tbody>
+                {isLoading && skeletonRows}
 
-        <div className="table-responsive">
-          <Table hover className="align-middle mb-0">
-            <thead>
-              <tr>
-                <th scope="col">Presupuesto</th>
-                <th scope="col">Título</th>
-                <th scope="col">Cliente</th>
-                <th scope="col">Sede</th>
-                <th scope="col">Formación</th>
-              </tr>
-            </thead>
-            <tbody>
-              {isLoading && (
-                <>
-                  {Array.from({ length: 4 }).map((_, index) => (
-                    <tr key={`skeleton-${index}`}>
-                      {Array.from({ length: 5 }).map((__, cell) => (
-                        <td key={cell}>
-                          <Placeholder animation="wave" xs={12} className="rounded-pill" />
-                        </td>
-                      ))}
+                {!isLoading && data && data.length > 0 &&
+                  data.map((deal) => (
+                    <tr
+                      key={deal.id}
+                      role="button"
+                      style={{ cursor: 'pointer' }}
+                      onClick={() => handleSelectDeal(deal.id)}
+                    >
+                      <td className="fw-semibold text-primary">#{deal.id}</td>
+                      <td>{deal.title}</td>
+                      <td>{deal.clientName ?? 'Sin organización asociada'}</td>
+                      <td>{deal.sede ?? 'Sin sede definida'}</td>
+                      <td className="text-nowrap">
+                        {deal.formations.length > 0 ? (
+                          <Stack direction="horizontal" gap={2} className="flex-wrap">
+                            {deal.formations.map((name) => (
+                              <Badge key={name} bg="info" text="dark" className="px-3 py-2 rounded-pill">
+                                {name}
+                              </Badge>
+                            ))}
+                          </Stack>
+                        ) : (
+                          <span className="text-muted">Sin formaciones form-</span>
+                        )}
+                      </td>
                     </tr>
                   ))}
-                </>
-              )}
-
-              {!isLoading && data && data.length > 0 && data.map(renderRow)}
-            </tbody>
-          </Table>
-        </div>
-
-        {!isLoading && data && data.length === 0 && !isError && (
-          <div className="text-center py-5 text-secondary">
-            <p className="fw-semibold">No hay presupuestos en el embudo seleccionado.</p>
-            <p className="mb-0">En cuanto un presupuesto se marque como ganado en Pipedrive, aparecerá automáticamente aquí.</p>
+              </tbody>
+            </Table>
           </div>
-        )}
-      </Card.Body>
-    </Card>
+
+          {!isLoading && data && data.length === 0 && !isError && (
+            <div className="text-center py-5 text-secondary">
+              <p className="fw-semibold">No hay presupuestos en el embudo seleccionado.</p>
+              <p className="mb-0">En cuanto un presupuesto se marque como ganado en Pipedrive, aparecerá automáticamente aquí.</p>
+            </div>
+          )}
+        </Card.Body>
+      </Card>
+
+      {selectedDeal && (
+        <DealDetailModal
+          show
+          deal={selectedDeal}
+          onHide={handleCloseModal}
+          events={events}
+          onUpdateSchedule={onUpdateSchedule}
+          onDealRefetch={async () => {
+            try {
+              const refreshed = await fetchDealById(selectedDeal.id);
+              queryClient.setQueryData<DealRecord[]>(['deals', 'stage-3'], (previous) => {
+                const current = previous ?? [];
+                const filtered = current.filter((item) => item.id !== refreshed.id);
+                return [refreshed, ...filtered];
+              });
+            } catch (refreshError) {
+              console.error('No se pudo actualizar el deal seleccionado', refreshError);
+            }
+          }}
+        />
+      )}
+    </>
   );
 };
 

--- a/src/services/calendar.ts
+++ b/src/services/calendar.ts
@@ -1,0 +1,53 @@
+export interface CalendarEvent {
+  id: string;
+  dealId: number;
+  dealTitle: string;
+  dealProductId: number;
+  productId: number | null;
+  productName: string;
+  sessionIndex: number;
+  start: string;
+  end: string;
+  attendees: number | null;
+  sede: string | null;
+  address: string | null;
+}
+
+const STORAGE_KEY = 'erp-calendar-events-v1';
+
+const isBrowser = typeof window !== 'undefined';
+
+export const loadCalendarEvents = (): CalendarEvent[] => {
+  if (!isBrowser) {
+    return [];
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+
+    const parsed = JSON.parse(raw) as CalendarEvent[];
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.filter((event) => typeof event?.id === 'string' && typeof event?.dealId === 'number');
+  } catch (error) {
+    console.error('No se pudieron cargar los eventos del calendario desde el almacenamiento local', error);
+    return [];
+  }
+};
+
+export const persistCalendarEvents = (events: CalendarEvent[]) => {
+  if (!isBrowser) {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(events));
+  } catch (error) {
+    console.error('No se pudieron guardar los eventos del calendario en el almacenamiento local', error);
+  }
+};

--- a/src/services/dealExtras.ts
+++ b/src/services/dealExtras.ts
@@ -1,0 +1,72 @@
+export interface StoredDealNote {
+  id: string;
+  content: string;
+  createdAt: string;
+  dealProductId?: number | null;
+  productId?: number | null;
+  productName?: string | null;
+}
+
+export interface StoredDealDocument {
+  id: string;
+  name: string;
+  url: string;
+  createdAt: string;
+  dealProductId?: number | null;
+  productId?: number | null;
+  productName?: string | null;
+}
+
+export interface StoredDealExtras {
+  notes: StoredDealNote[];
+  documents: StoredDealDocument[];
+}
+
+const STORAGE_KEY = 'erp-deal-extras-v1';
+const isBrowser = typeof window !== 'undefined';
+
+const readStorage = (): Record<string, StoredDealExtras> => {
+  if (!isBrowser) {
+    return {};
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return {};
+    }
+
+    const parsed = JSON.parse(raw) as Record<string, StoredDealExtras>;
+    if (parsed && typeof parsed === 'object') {
+      return parsed;
+    }
+
+    return {};
+  } catch (error) {
+    console.error('No se pudieron leer las notas locales del almacenamiento', error);
+    return {};
+  }
+};
+
+const writeStorage = (value: Record<string, StoredDealExtras>) => {
+  if (!isBrowser) {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+  } catch (error) {
+    console.error('No se pudieron guardar las notas locales en el almacenamiento', error);
+  }
+};
+
+export const loadDealExtras = (dealId: number): StoredDealExtras => {
+  const storage = readStorage();
+  return storage[String(dealId)] ?? { notes: [], documents: [] };
+};
+
+export const persistDealExtras = (dealId: number, extras: StoredDealExtras) => {
+  const storage = readStorage();
+  storage[String(dealId)] = extras;
+  writeStorage(storage);
+};

--- a/src/services/deals.ts
+++ b/src/services/deals.ts
@@ -1,10 +1,54 @@
+export interface DealNote {
+  id: string;
+  content: string;
+  createdAt: string | null;
+  authorName: string | null;
+  source: 'deal' | 'product' | 'local';
+  productId: number | null;
+  dealProductId: number | null;
+}
+
+export interface DealAttachment {
+  id: string;
+  name: string;
+  url: string;
+  downloadUrl: string | null;
+  fileType: string | null;
+  addedAt: string | null;
+  addedBy: string | null;
+  source: 'deal' | 'product' | 'local';
+  productId: number | null;
+  dealProductId: number | null;
+}
+
+export interface DealProduct {
+  dealProductId: number;
+  productId: number | null;
+  name: string;
+  code: string | null;
+  quantity: number;
+  itemPrice: number | null;
+  recommendedHours: number | null;
+  recommendedHoursRaw: string | null;
+  notes: DealNote[];
+  attachments: DealAttachment[];
+  isTraining: boolean;
+}
+
 export interface DealRecord {
   id: number;
   title: string;
   clientId: number | null;
   clientName: string | null;
   sede: string | null;
+  address: string | null;
+  pipelineId: number | null;
+  pipelineName: string | null;
   formations: string[];
+  trainingProducts: DealProduct[];
+  extraProducts: DealProduct[];
+  notes: DealNote[];
+  attachments: DealAttachment[];
 }
 
 interface DealsResponse {


### PR DESCRIPTION
## Summary
- Extend the Netlify deals function to hydrate each record with pipeline metadata, address, training and extra products, recommended hours, notes and attachments pulled from Pipedrive. 【F:netlify/functions/deals.ts†L1-L632】
- Add a DealDetailModal that presents full deal information, manages local notes and documents, and drives multi-session calendar scheduling with date, time, sede and address inputs plus Google Maps support. 【F:src/components/deals/DealDetailModal.tsx†L1-L1034】
- Persist scheduling and extra metadata locally and surface it across the app by updating the calendar view, deals board and app shell alongside new storage helpers. 【F:src/App.tsx†L1-L37】【F:src/components/calendar/CalendarView.tsx†L1-L64】【F:src/components/deals/DealsBoard.tsx†L1-L218】【F:src/services/calendar.ts†L1-L53】【F:src/services/dealExtras.ts†L1-L71】

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1202e9d0083288de74250eabcb034