### PR TITLE
Add won date column with sortable deals table

### DIFF
--- a/netlify/functions/deals.ts
+++ b/netlify/functions/deals.ts
@@ -101,6 +101,7 @@ interface NormalisedDeal {
   address: string | null;
   pipelineId: number | null;
   pipelineName: string | null;
+  wonDate: string | null;
   formations: string[];
   trainingProducts: NormalisedProduct[];
   extraProducts: NormalisedProduct[];
@@ -196,6 +197,15 @@ const parseAuthorName = (value: unknown): string | null => {
   }
 
   return null;
+};
+
+const parseDateValue = (value: unknown): string | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
 };
 
 const normaliseNote = (
@@ -584,6 +594,7 @@ const normaliseDeal = async (
 
   const pipelineId = toInteger(deal.pipeline_id);
   const pipelineName = pipelineId != null ? pipelineMap.get(pipelineId) ?? null : null;
+  const wonDate = parseDateValue((deal as Record<string, unknown>).won_time);
 
   const [products, dealNotes, dealFiles] = await Promise.all([
     fetchDealProductsDetailed(deal.id, caches),
@@ -622,6 +633,7 @@ const normaliseDeal = async (
     address,
     pipelineId,
     pipelineName,
+    wonDate,
     formations,
     trainingProducts,
     extraProducts,

--- a/src/App.scss
+++ b/src/App.scss
@@ -75,6 +75,33 @@
   font-size: 0.95rem;
 }
 
+.table-sort-button {
+  border: 0;
+  background: transparent;
+  padding: 0;
+  color: inherit;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  cursor: pointer;
+}
+
+.table-sort-button:hover {
+  color: var(--brand-primary);
+}
+
+.table-sort-button:focus-visible {
+  outline: 2px solid var(--brand-primary);
+  outline-offset: 2px;
+  border-radius: 0.5rem;
+}
+
+.table-sort-indicator {
+  font-size: 0.75rem;
+  line-height: 1;
+}
+
 @media (max-width: 768px) {
   .calendar-card,
   .deals-card {

--- a/src/components/deals/DealsBoard.tsx
+++ b/src/components/deals/DealsBoard.tsx
@@ -11,9 +11,10 @@ import { CalendarEvent } from '../../services/calendar';
 import { fetchDealById, fetchDeals, DealRecord } from '../../services/deals';
 import DealDetailModal from './DealDetailModal';
 
+const skeletonColumnCount = 6;
 const skeletonRows = Array.from({ length: 4 }, (_, index) => (
   <tr key={`skeleton-${index}`}>
-    {Array.from({ length: 5 }).map((__, cell) => (
+    {Array.from({ length: skeletonColumnCount }).map((__, cell) => (
       <td key={cell}>
         <Placeholder animation="wave" xs={12} className="rounded-pill" />
       </td>
@@ -22,6 +23,13 @@ const skeletonRows = Array.from({ length: 4 }, (_, index) => (
 ));
 
 type FeedbackState = { type: 'success' | 'error'; message: string } | null;
+type SortField = 'id' | 'wonDate' | 'title' | 'clientName' | 'sede' | 'formations';
+type SortDirection = 'asc' | 'desc';
+
+interface SortConfig {
+  field: SortField;
+  direction: SortDirection;
+}
 
 interface DealsBoardProps {
   events: CalendarEvent[];
@@ -32,11 +40,144 @@ const DealsBoard = ({ events, onUpdateSchedule }: DealsBoardProps) => {
   const queryClient = useQueryClient();
   const [feedback, setFeedback] = useState<FeedbackState>(null);
   const [selectedDealId, setSelectedDealId] = useState<number | null>(null);
+  const [sortConfig, setSortConfig] = useState<SortConfig>({ field: 'wonDate', direction: 'desc' });
   const { data, isLoading, isError, error, refetch, isFetching } = useQuery({
     queryKey: ['deals', 'stage-3'],
     queryFn: fetchDeals,
     staleTime: 1000 * 60
   });
+
+  const dateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat('es-ES', {
+        dateStyle: 'medium'
+      }),
+    []
+  );
+
+  const fallbackClientName = 'Sin organización asociada';
+  const fallbackSede = 'Sin sede definida';
+  const fallbackFormationsLabel = 'Sin formaciones form-';
+
+  const formatDealDate = (value: string | null) => {
+    if (!value) {
+      return 'Sin fecha';
+    }
+
+    const timestamp = Date.parse(value);
+
+    if (Number.isNaN(timestamp)) {
+      return value;
+    }
+
+    return dateFormatter.format(new Date(timestamp));
+  };
+
+  const sortedDeals = useMemo<DealRecord[]>(() => {
+    if (!data) {
+      return [];
+    }
+
+    const items = [...data];
+    const { field, direction } = sortConfig;
+    const multiplier = direction === 'asc' ? 1 : -1;
+
+    const normaliseString = (input: string | null | undefined) => (input ?? '').trim();
+
+    const compareStrings = (
+      firstValue: string | null | undefined,
+      secondValue: string | null | undefined
+    ) => normaliseString(firstValue).localeCompare(normaliseString(secondValue), 'es', { sensitivity: 'base' });
+
+    const parseDateForSort = (value: string | null) => {
+      if (!value) {
+        return Number.NEGATIVE_INFINITY;
+      }
+
+      const timestamp = Date.parse(value);
+      return Number.isNaN(timestamp) ? Number.NEGATIVE_INFINITY : timestamp;
+    };
+
+    items.sort((first, second) => {
+      let comparison = 0;
+
+      switch (field) {
+        case 'id':
+          comparison = first.id - second.id;
+          break;
+        case 'wonDate':
+          comparison = parseDateForSort(first.wonDate) - parseDateForSort(second.wonDate);
+          break;
+        case 'title':
+          comparison = compareStrings(first.title, second.title);
+          break;
+        case 'clientName':
+          comparison = compareStrings(first.clientName ?? fallbackClientName, second.clientName ?? fallbackClientName);
+          break;
+        case 'sede':
+          comparison = compareStrings(first.sede ?? fallbackSede, second.sede ?? fallbackSede);
+          break;
+        case 'formations': {
+          const firstLabel =
+            first.formations.length > 0 ? first.formations.join(', ') : fallbackFormationsLabel;
+          const secondLabel =
+            second.formations.length > 0 ? second.formations.join(', ') : fallbackFormationsLabel;
+          comparison = compareStrings(firstLabel, secondLabel);
+          break;
+        }
+        default:
+          comparison = 0;
+      }
+
+      if (comparison === 0) {
+        comparison = first.id - second.id;
+      }
+
+      return comparison * multiplier;
+    });
+
+    return items;
+  }, [data, sortConfig, fallbackClientName, fallbackFormationsLabel, fallbackSede]);
+
+  const handleSort = (field: SortField) => {
+    setSortConfig((current) => {
+      if (current.field === field) {
+        return { field, direction: current.direction === 'asc' ? 'desc' : 'asc' };
+      }
+
+      const defaultDirection: SortDirection = field === 'id' || field === 'wonDate' ? 'desc' : 'asc';
+      return { field, direction: defaultDirection };
+    });
+  };
+
+  const getAriaSort = (field: SortField): 'ascending' | 'descending' | undefined => {
+    if (sortConfig.field !== field) {
+      return undefined;
+    }
+
+    return sortConfig.direction === 'asc' ? 'ascending' : 'descending';
+  };
+
+  const renderSortButton = (label: string, field: SortField) => {
+    const isActive = sortConfig.field === field;
+    const direction = isActive ? sortConfig.direction : null;
+
+    return (
+      <button
+        type="button"
+        className="table-sort-button"
+        onClick={() => handleSort(field)}
+        aria-label={`Ordenar por ${label}`}
+      >
+        <span>{label}</span>
+        {direction && (
+          <span className="table-sort-indicator" aria-hidden="true">
+            {direction === 'asc' ? '▲' : '▼'}
+          </span>
+        )}
+      </button>
+    );
+  };
 
   const uploadDeal = useMutation({
     mutationFn: fetchDealById,
@@ -144,18 +285,31 @@ const DealsBoard = ({ events, onUpdateSchedule }: DealsBoardProps) => {
             <Table hover className="align-middle mb-0">
               <thead>
                 <tr>
-                  <th scope="col">Presupuesto</th>
-                  <th scope="col">Título</th>
-                  <th scope="col">Cliente</th>
-                  <th scope="col">Sede</th>
-                  <th scope="col">Formación</th>
+                  <th scope="col" aria-sort={getAriaSort('id')}>
+                    {renderSortButton('Presupuesto', 'id')}
+                  </th>
+                  <th scope="col" aria-sort={getAriaSort('wonDate')}>
+                    {renderSortButton('Fecha de ganado', 'wonDate')}
+                  </th>
+                  <th scope="col" aria-sort={getAriaSort('title')}>
+                    {renderSortButton('Título', 'title')}
+                  </th>
+                  <th scope="col" aria-sort={getAriaSort('clientName')}>
+                    {renderSortButton('Cliente', 'clientName')}
+                  </th>
+                  <th scope="col" aria-sort={getAriaSort('sede')}>
+                    {renderSortButton('Sede', 'sede')}
+                  </th>
+                  <th scope="col" aria-sort={getAriaSort('formations')}>
+                    {renderSortButton('Formación', 'formations')}
+                  </th>
                 </tr>
               </thead>
               <tbody>
                 {isLoading && skeletonRows}
 
-                {!isLoading && data && data.length > 0 &&
-                  data.map((deal) => (
+                {!isLoading && sortedDeals.length > 0 &&
+                  sortedDeals.map((deal) => (
                     <tr
                       key={deal.id}
                       role="button"
@@ -163,10 +317,11 @@ const DealsBoard = ({ events, onUpdateSchedule }: DealsBoardProps) => {
                       onClick={() => handleSelectDeal(deal.id)}
                     >
                       <td className="fw-semibold text-primary">#{deal.id}</td>
+                      <td className="text-nowrap">{formatDealDate(deal.wonDate)}</td>
                       <td>{deal.title}</td>
-                      <td>{deal.clientName ?? 'Sin organización asociada'}</td>
-                      <td>{deal.sede ?? 'Sin sede definida'}</td>
-                      <td className="text-nowrap">
+                      <td>{deal.clientName ?? fallbackClientName}</td>
+                      <td>{deal.sede ?? fallbackSede}</td>
+                      <td>
                         {deal.formations.length > 0 ? (
                           <Stack direction="horizontal" gap={2} className="flex-wrap">
                             {deal.formations.map((name) => (
@@ -176,7 +331,7 @@ const DealsBoard = ({ events, onUpdateSchedule }: DealsBoardProps) => {
                             ))}
                           </Stack>
                         ) : (
-                          <span className="text-muted">Sin formaciones form-</span>
+                          <span className="text-muted">{fallbackFormationsLabel}</span>
                         )}
                       </td>
                     </tr>

--- a/src/services/deals.ts
+++ b/src/services/deals.ts
@@ -44,6 +44,7 @@ export interface DealRecord {
   address: string | null;
   pipelineId: number | null;
   pipelineName: string | null;
+  wonDate: string | null;
   formations: string[];
   trainingProducts: DealProduct[];
   extraProducts: DealProduct[];


### PR DESCRIPTION
## Summary
- expose the won date on the Netlify deals function and frontend types
- display the won date column and add client-side sorting for every deals table column
- style the sortable table headers for better affordance

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d12eb13a088328b4b5b17fcda16b61