### PR TITLE
Add logistics details to calendar sessions

### DIFF
--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -22,6 +22,19 @@ const buildEventTitle = (event: CalendarEvent) => {
     segments.push(event.sede);
   }
 
+  if (event.mobileUnit) {
+    segments.push(`Unidad: ${event.mobileUnit}`);
+  }
+
+  if (event.trainers && event.trainers.length > 0) {
+    const label = event.trainers.length === 1 ? 'Formador' : 'Formadores';
+    segments.push(`${label}: ${event.trainers.join(', ')}`);
+  }
+
+  if (event.logisticsInfo) {
+    segments.push(`Info logística: ${event.logisticsInfo}`);
+  }
+
   return segments.join(' · ');
 };
 
@@ -56,7 +69,10 @@ const CalendarView = ({ events }: CalendarViewProps) => (
               productName: event.productName,
               attendees: event.attendees,
               sede: event.sede,
-              address: event.address
+              address: event.address,
+              trainers: event.trainers,
+              mobileUnit: event.mobileUnit,
+              logisticsInfo: event.logisticsInfo
             }
           }))}
           locales={[esLocale]}

--- a/src/services/calendar.ts
+++ b/src/services/calendar.ts
@@ -11,11 +11,73 @@ export interface CalendarEvent {
   attendees: number | null;
   sede: string | null;
   address: string | null;
+  trainers: string[];
+  mobileUnit: string | null;
+  logisticsInfo: string | null;
 }
 
 const STORAGE_KEY = 'erp-calendar-events-v1';
 
 const isBrowser = typeof window !== 'undefined';
+
+type StoredCalendarEvent = Partial<CalendarEvent> & { id: string; dealId: number };
+
+const isStoredCalendarEvent = (event: unknown): event is StoredCalendarEvent => {
+  if (!event || typeof event !== 'object') {
+    return false;
+  }
+
+  const candidate = event as { id?: unknown; dealId?: unknown };
+  return typeof candidate.id === 'string' && typeof candidate.dealId === 'number';
+};
+
+const sanitizeCalendarEvent = (event: StoredCalendarEvent): CalendarEvent => {
+  const parseString = (value: unknown, fallback = ''): string =>
+    typeof value === 'string' ? value : fallback;
+
+  const parseOptionalString = (value: unknown): string | null => {
+    if (typeof value !== 'string') {
+      return null;
+    }
+
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  };
+
+  const parseNumber = (value: unknown, fallback: number): number =>
+    typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+
+  const parseOptionalNumber = (value: unknown): number | null =>
+    typeof value === 'number' && Number.isFinite(value) ? value : null;
+
+  const trainers = Array.isArray(event.trainers)
+    ? Array.from(
+        new Set(
+          event.trainers
+            .map((trainer) => (typeof trainer === 'string' ? trainer.trim() : ''))
+            .filter((trainer) => trainer.length > 0)
+        )
+      )
+    : [];
+
+  return {
+    id: event.id,
+    dealId: event.dealId,
+    dealTitle: parseString(event.dealTitle),
+    dealProductId: parseNumber(event.dealProductId, 0),
+    productId: parseOptionalNumber(event.productId),
+    productName: parseString(event.productName),
+    sessionIndex: parseNumber(event.sessionIndex, 0),
+    start: parseString(event.start),
+    end: parseString(event.end),
+    attendees: parseOptionalNumber(event.attendees),
+    sede: parseOptionalString(event.sede),
+    address: parseOptionalString(event.address),
+    trainers,
+    mobileUnit: parseOptionalString(event.mobileUnit),
+    logisticsInfo: parseOptionalString(event.logisticsInfo)
+  };
+};
 
 export const loadCalendarEvents = (): CalendarEvent[] => {
   if (!isBrowser) {
@@ -28,12 +90,12 @@ export const loadCalendarEvents = (): CalendarEvent[] => {
       return [];
     }
 
-    const parsed = JSON.parse(raw) as CalendarEvent[];
+    const parsed: unknown = JSON.parse(raw);
     if (!Array.isArray(parsed)) {
       return [];
     }
 
-    return parsed.filter((event) => typeof event?.id === 'string' && typeof event?.dealId === 'number');
+    return (parsed as unknown[]).filter(isStoredCalendarEvent).map(sanitizeCalendarEvent);
   } catch (error) {
     console.error('No se pudieron cargar los eventos del calendario desde el almacenamiento local', error);
     return [];


### PR DESCRIPTION
## Summary
- add trainer, mobile unit, and logistics info fields to the deal scheduling modal with predefined options and updated layout
- persist the new session details when saving calendar events and normalise stored data when loading from local storage
- expose trainers, unit, and logistics information on calendar entries so the planning view shows the added context

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d13a42ef8c832893a7435b0c1f9f35