### PR TITLE
Adjust hours field alignment in deal detail modal

### DIFF
--- a/src/components/deals/DealDetailModal.tsx
+++ b/src/components/deals/DealDetailModal.tsx
@@ -808,8 +808,8 @@ const DealDetailModal = ({
                         <>
                           <Row className="g-2 align-items-center text-uppercase text-muted small mb-2">
                             <Col md={8} sm={7}>Formación</Col>
-                            <Col md={4} sm={5} className="text-md-end">
-                              <span className="d-inline-block w-100">Horas</span>
+                            <Col md={4} sm={5}>
+                              <span className="d-inline-block w-100 text-start">Horas</span>
                             </Col>
                           </Row>
                           <Stack gap={2}>
@@ -821,19 +821,27 @@ const DealDetailModal = ({
                                   </div>
                                 </Col>
                                 <Col md={4} sm={5}>
-                                  <Form.Group controlId={`recommended-hours-${product.dealProductId}`} className="mb-0">
-                                    <Form.Label className="visually-hidden">Horas</Form.Label>
-                                    <Form.Control
-                                      type="number"
-                                      min={0}
-                                      step={0.5}
-                                      value={recommendedHoursByProduct[product.dealProductId] ?? ''}
-                                      onChange={(event) =>
-                                        handleRecommendedHoursChange(product.dealProductId, event.target.value)
-                                      }
-                                      placeholder="Sin horas"
-                                      aria-label="Horas recomendadas"
-                                    />
+                                  <Form.Group
+                                    controlId={`recommended-hours-${product.dealProductId}`}
+                                    className="mb-0"
+                                  >
+                                    <div className="d-flex align-items-center gap-2 flex-wrap">
+                                      <Form.Label className="mb-0 text-uppercase text-muted small">
+                                        Horas
+                                      </Form.Label>
+                                      <Form.Control
+                                        type="number"
+                                        min={0}
+                                        step={0.5}
+                                        value={recommendedHoursByProduct[product.dealProductId] ?? ''}
+                                        onChange={(event) =>
+                                          handleRecommendedHoursChange(product.dealProductId, event.target.value)
+                                        }
+                                        placeholder="Sin horas"
+                                        aria-label="Horas recomendadas"
+                                        className="w-50"
+                                      />
+                                    </div>
                                   </Form.Group>
                                 </Col>
                               </Row>


### PR DESCRIPTION
## Summary
- align the hours column heading with the inputs
- show the hours label to the left of each field and reduce the input width to half

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d15405ef6083289bb746432acc0435