### PR TITLE
Fix notes retrieval by using correct Pipedrive sort parameter

### DIFF
--- a/netlify/functions/deals.ts
+++ b/netlify/functions/deals.ts
@@ -460,8 +460,7 @@ const fetchDealNotes = async (dealId: number): Promise<NormalisedNote[]> => {
 
   try {
     const response = await fetchJson<NotesResponse>(`deals/${dealId}/notes`, {
-      sort_by: 'add_time',
-      sort_direction: 'desc'
+      sort: 'add_time DESC'
     });
 
     const notes = response.data ?? [];
@@ -526,8 +525,7 @@ const fetchProductNotes = async (
 
   try {
     const response = await fetchJson<NotesResponse>(`products/${productId}/notes`, {
-      sort_by: 'add_time',
-      sort_direction: 'desc'
+      sort: 'add_time DESC'
     });
 
     const notes = (response.data ?? [])


### PR DESCRIPTION
## Summary
- update the Netlify deals function so notes requests use the correct `sort` parameter when calling the Pipedrive API
- ensure both deal-level and product-level note fetches return data instead of failing due to unsupported query params

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d154b3fd7483289da5f6832bae3a54