### PR TITLE
Adjust recommended hours layout

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -102,6 +102,22 @@
   line-height: 1;
 }
 
+.recommended-hours-label {
+  display: inline-block;
+  width: min(9rem, 100%);
+  text-align: left;
+}
+
+.recommended-hours-field {
+  width: min(9rem, 100%);
+  flex: 0 0 auto;
+}
+
+.recommended-hours-field .form-control,
+.recommended-hours-input {
+  width: 100%;
+}
+
 @media (max-width: 768px) {
   .calendar-card,
   .deals-card {

--- a/src/components/deals/DealDetailModal.tsx
+++ b/src/components/deals/DealDetailModal.tsx
@@ -856,8 +856,8 @@ const DealDetailModal = ({
                         <>
                           <Row className="g-2 align-items-center text-uppercase text-muted small mb-2">
                             <Col md={8} sm={7}>Formación</Col>
-                            <Col md={4} sm={5}>
-                              <span className="d-inline-block w-100 text-start">Horas</span>
+                            <Col md={4} sm={5} className="d-flex justify-content-end">
+                              <span className="recommended-hours-label">Horas</span>
                             </Col>
                           </Row>
                           <Stack gap={2}>
@@ -868,28 +868,23 @@ const DealDetailModal = ({
                                     {product.name}
                                   </div>
                                 </Col>
-                                <Col md={4} sm={5}>
+                                <Col md={4} sm={5} className="d-flex justify-content-end">
                                   <Form.Group
                                     controlId={`recommended-hours-${product.dealProductId}`}
-                                    className="mb-0"
+                                    className="mb-0 recommended-hours-field"
                                   >
-                                    <div className="d-flex align-items-center gap-2 flex-wrap">
-                                      <Form.Label className="mb-0 text-uppercase text-muted small">
-                                        Horas
-                                      </Form.Label>
-                                      <Form.Control
-                                        type="number"
-                                        min={0}
-                                        step={0.5}
-                                        value={recommendedHoursByProduct[product.dealProductId] ?? ''}
-                                        onChange={(event) =>
-                                          handleRecommendedHoursChange(product.dealProductId, event.target.value)
-                                        }
-                                        placeholder="Sin horas"
-                                        aria-label="Horas recomendadas"
-                                        className="w-50"
-                                      />
-                                    </div>
+                                    <Form.Control
+                                      type="number"
+                                      min={0}
+                                      step={0.5}
+                                      value={recommendedHoursByProduct[product.dealProductId] ?? ''}
+                                      onChange={(event) =>
+                                        handleRecommendedHoursChange(product.dealProductId, event.target.value)
+                                      }
+                                      placeholder="Sin horas"
+                                      aria-label="Horas recomendadas"
+                                      className="recommended-hours-input"
+                                    />
                                   </Form.Group>
                                 </Col>
                               </Row>


### PR DESCRIPTION
## Summary
- remove the inline "Horas" form label to keep the input box in place
- align the header label with the hours input through a shared width helper class
- add supporting styles to keep the new alignment consistent across breakpoints

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1579f3a188328bcb159de4cb94c85