### PR TITLE
Permitir abrir detalle de deal desde el calendario

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,28 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import Button from 'react-bootstrap/Button';
 import Container from 'react-bootstrap/Container';
+import Modal from 'react-bootstrap/Modal';
 import Stack from 'react-bootstrap/Stack';
 import CalendarView from './components/calendar/CalendarView';
 import DealsBoard from './components/deals/DealsBoard';
+import DealDetailModal from './components/deals/DealDetailModal';
 import HeaderBar from './components/layout/HeaderBar';
 import { CalendarEvent, loadCalendarEvents, persistCalendarEvents } from './services/calendar';
+import { fetchDealById, DealRecord } from './services/deals';
 import './App.scss';
 
 type TabKey = 'calendar' | 'backlog';
 
+type CalendarModalStatus = 'idle' | 'loading' | 'success' | 'error';
+
 const App = () => {
   const [activeTab, setActiveTab] = useState<TabKey>('calendar');
   const [calendarEvents, setCalendarEvents] = useState<CalendarEvent[]>(() => loadCalendarEvents());
+  const [isCalendarModalOpen, setIsCalendarModalOpen] = useState(false);
+  const [calendarModalStatus, setCalendarModalStatus] = useState<CalendarModalStatus>('idle');
+  const [selectedCalendarDealId, setSelectedCalendarDealId] = useState<number | null>(null);
+  const [selectedCalendarDeal, setSelectedCalendarDeal] = useState<DealRecord | null>(null);
+  const [calendarModalError, setCalendarModalError] = useState<string | null>(null);
 
   useEffect(() => {
     persistCalendarEvents(calendarEvents);
@@ -24,6 +35,60 @@ const App = () => {
     });
   };
 
+  const loadCalendarDeal = useCallback(async (dealId: number) => {
+    setCalendarModalStatus('loading');
+    setCalendarModalError(null);
+    setSelectedCalendarDeal(null);
+
+    try {
+      const deal = await fetchDealById(dealId);
+      setSelectedCalendarDeal(deal);
+      setCalendarModalStatus('success');
+    } catch (error) {
+      console.error('No se pudo cargar el presupuesto seleccionado', error);
+      setCalendarModalStatus('error');
+      setCalendarModalError(
+        error instanceof Error
+          ? error.message
+          : 'No se pudo cargar el presupuesto seleccionado. Inténtalo de nuevo más tarde.'
+      );
+    }
+  }, []);
+
+  const handleCalendarEventSelect = useCallback(
+    (event: CalendarEvent) => {
+      setSelectedCalendarDealId(event.dealId);
+      setIsCalendarModalOpen(true);
+      void loadCalendarDeal(event.dealId);
+    },
+    [loadCalendarDeal]
+  );
+
+  const handleCalendarModalClose = useCallback(() => {
+    setIsCalendarModalOpen(false);
+    setCalendarModalStatus('idle');
+    setSelectedCalendarDealId(null);
+    setSelectedCalendarDeal(null);
+    setCalendarModalError(null);
+  }, []);
+
+  const handleCalendarModalRetry = useCallback(() => {
+    if (selectedCalendarDealId == null) {
+      return;
+    }
+
+    void loadCalendarDeal(selectedCalendarDealId);
+  }, [loadCalendarDeal, selectedCalendarDealId]);
+
+  const handleCalendarDealRefetch = useCallback(async () => {
+    if (selectedCalendarDealId == null) {
+      throw new Error('No hay un presupuesto seleccionado para actualizar.');
+    }
+
+    const refreshed = await fetchDealById(selectedCalendarDealId);
+    setSelectedCalendarDeal(refreshed);
+  }, [selectedCalendarDealId]);
+
   return (
     <div className="app-shell">
       <HeaderBar onNavigate={setActiveTab} activeKey={activeTab} />
@@ -31,13 +96,56 @@ const App = () => {
         <Container fluid className="pt-4 pb-5">
           <Stack gap={4}>
             {activeTab === 'calendar' ? (
-              <CalendarView events={calendarEvents} />
+              <CalendarView events={calendarEvents} onSelectEvent={handleCalendarEventSelect} />
             ) : (
               <DealsBoard events={calendarEvents} onUpdateSchedule={handleUpdateSchedule} />
             )}
           </Stack>
         </Container>
       </main>
+
+      {isCalendarModalOpen && calendarModalStatus === 'loading' && (
+        <Modal show centered backdrop="static" keyboard={false} onHide={handleCalendarModalClose}>
+          <Modal.Body className="py-5 text-center">
+            <div className="mb-3">
+              <span className="spinner-border" role="status" aria-hidden="true" />
+            </div>
+            <div>Cargando presupuesto...</div>
+          </Modal.Body>
+        </Modal>
+      )}
+
+      {isCalendarModalOpen && calendarModalStatus === 'error' && (
+        <Modal show centered onHide={handleCalendarModalClose}>
+          <Modal.Header closeButton>
+            <Modal.Title>No se pudo cargar el presupuesto</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <p className="mb-0">
+              {calendarModalError ?? 'No se pudo cargar el presupuesto seleccionado. Inténtalo de nuevo más tarde.'}
+            </p>
+          </Modal.Body>
+          <Modal.Footer>
+            <Button variant="secondary" onClick={handleCalendarModalClose}>
+              Cerrar
+            </Button>
+            <Button variant="primary" onClick={handleCalendarModalRetry} disabled={selectedCalendarDealId == null}>
+              Reintentar
+            </Button>
+          </Modal.Footer>
+        </Modal>
+      )}
+
+      {isCalendarModalOpen && calendarModalStatus === 'success' && selectedCalendarDeal && (
+        <DealDetailModal
+          show
+          deal={selectedCalendarDeal}
+          onHide={handleCalendarModalClose}
+          events={calendarEvents}
+          onUpdateSchedule={handleUpdateSchedule}
+          onDealRefetch={handleCalendarDealRefetch}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -1,3 +1,4 @@
+import type { EventClickArg } from '@fullcalendar/core';
 import FullCalendar from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import timeGridPlugin from '@fullcalendar/timegrid';
@@ -9,6 +10,7 @@ import { CalendarEvent } from '../../services/calendar';
 
 interface CalendarViewProps {
   events: CalendarEvent[];
+  onSelectEvent?: (event: CalendarEvent) => void;
 }
 
 const buildEventTitle = (event: CalendarEvent) => {
@@ -39,7 +41,7 @@ const buildEventTitle = (event: CalendarEvent) => {
   return segments.join(' · ');
 };
 
-const CalendarView = ({ events }: CalendarViewProps) => (
+const CalendarView = ({ events, onSelectEvent }: CalendarViewProps) => (
   <Card className="calendar-card border-0">
     <Card.Body className="p-0">
       <div className="calendar-scroll-container">
@@ -76,6 +78,17 @@ const CalendarView = ({ events }: CalendarViewProps) => (
               logisticsInfo: event.logisticsInfo
             }
           }))}
+          eventClick={(info: EventClickArg) => {
+            if (!onSelectEvent) {
+              return;
+            }
+
+            const calendarEvent = events.find((item) => item.id === info.event.id);
+
+            if (calendarEvent) {
+              onSelectEvent(calendarEvent);
+            }
+          }}
           locales={[esLocale]}
           locale="es"
         />


### PR DESCRIPTION
## Summary
- permite seleccionar sesiones en el calendario para abrir el modal de detalle del presupuesto
- añade estados de carga y error al abrir el modal desde el calendario reutilizando DealDetailModal

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d15cf3a5d083289b5af0f2e74076c6