### PR TITLE
Update note modal share selector

### DIFF
--- a/src/services/dealExtras.ts
+++ b/src/services/dealExtras.ts
@@ -5,6 +5,7 @@ export interface StoredDealNote {
   dealProductId?: number | null;
   productId?: number | null;
   productName?: string | null;
+  shareWithTrainer?: boolean | null;
 }
 
 export interface StoredDealDocument {


### PR DESCRIPTION
## Summary
- store note metadata indicating whether it should be shared with a trainer
- remove product targeting from the add note modal and replace it with a trainer sharing selector
- surface the trainer sharing choice alongside locally created notes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d16c42be68832889b07f6d67cf7f1e