### PR TITLE
Renombrar pestaña Sin fecha a Presupuestos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GEP Group · Planificación
 
-ERP interno enfocado en la planificación de formaciones. Incluye la estructura base del frontend en React + TypeScript con Vite, estilos iniciales alineados con el branding de GEP Group, un calendario FullCalendar vacío y la vista de "Presupuestos sin fecha" alimentada desde Pipedrive a través de una función serverless de Netlify.
+ERP interno enfocado en la planificación de formaciones. Incluye la estructura base del frontend en React + TypeScript con Vite, estilos iniciales alineados con el branding de GEP Group, un calendario FullCalendar vacío y la vista de "Presupuestos" alimentada desde Pipedrive a través de una función serverless de Netlify.
 
 ## Tecnologías principales
 
@@ -44,7 +44,7 @@ La configuración recomendada de Netlify es:
 ## Próximos pasos sugeridos
 
 - Sincronizar eventos reales en el calendario a partir de las fechas planificadas.
-- Permitir que los usuarios asignen fechas desde la vista de "Sin fecha" y reflejarlo en Pipedrive.
+- Permitir que los usuarios asignen fechas desde la vista de "Presupuestos" y reflejarlo en Pipedrive.
 - Añadir filtros y búsqueda avanzada por cliente, sede o tipo de formación.
 - Integrar progresivamente las APIs de Holded y WooCommerce.
 - Incorporar la carga y gestión de documentación mediante Google Workspace.

--- a/src/components/deals/DealsBoard.tsx
+++ b/src/components/deals/DealsBoard.tsx
@@ -416,7 +416,7 @@ const DealsBoard = ({ events, onUpdateSchedule }: DealsBoardProps) => {
 
   const handleRemoveDeal = (dealId: number) => {
     const confirmed = window.confirm(
-      '¿Quieres eliminar este deal de la lista de "Sin fecha"? Podrás recuperarlo subiéndolo de nuevo.'
+      '¿Quieres eliminar este deal de la lista de "Presupuestos"? Podrás recuperarlo subiéndolo de nuevo.'
     );
 
     if (!confirmed) {

--- a/src/components/layout/HeaderBar.tsx
+++ b/src/components/layout/HeaderBar.tsx
@@ -37,7 +37,7 @@ const HeaderBar = ({ activeKey, onNavigate }: HeaderBarProps) => (
           </Nav.Item>
           <Nav.Item>
             <Nav.Link eventKey="backlog" role="tab">
-              Sin fecha
+              Presupuestos
             </Nav.Link>
           </Nav.Item>
         </Nav>


### PR DESCRIPTION
## Summary
- renombrar la pestaña del backlog a "Presupuestos" en la cabecera
- actualizar el mensaje de confirmación del backlog y la documentación para reflejar el nuevo nombre

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1ace1ada0832880308ae6ab253f0d