### PR TITLE
Optimize deals summary loading and modal fetch flow

### DIFF
--- a/src/components/deals/DealDetailModal.tsx
+++ b/src/components/deals/DealDetailModal.tsx
@@ -10,6 +10,7 @@ import ListGroup from 'react-bootstrap/ListGroup';
 import Modal from 'react-bootstrap/Modal';
 import Row from 'react-bootstrap/Row';
 import Stack from 'react-bootstrap/Stack';
+import Spinner from 'react-bootstrap/Spinner';
 import Table from 'react-bootstrap/Table';
 import { CalendarEvent } from '../../services/calendar';
 import { DealAttachment, DealNote, DealProduct, DealRecord } from '../../services/deals';
@@ -23,6 +24,7 @@ import {
 interface DealDetailModalProps {
   show: boolean;
   deal: DealRecord;
+  isLoading: boolean;
   events: CalendarEvent[];
   onHide: () => void;
   onUpdateSchedule: (dealId: number, events: CalendarEvent[]) => void;
@@ -407,6 +409,7 @@ const updateSelectionSlot = (items: string[], index: number, value: string): str
 const DealDetailModal = ({
   show,
   deal,
+  isLoading,
   events,
   onHide,
   onUpdateSchedule,
@@ -1200,7 +1203,15 @@ const DealDetailModal = ({
           </div>
         </Modal.Header>
         <Modal.Body>
-          <Stack gap={4}>
+          {isLoading ? (
+            <div className="py-5 text-center">
+              <Spinner animation="border" role="status" className="mb-3">
+                <span className="visually-hidden">Cargando presupuesto…</span>
+              </Spinner>
+              <p className="mb-0">Cargando presupuesto…</p>
+            </div>
+          ) : (
+            <Stack gap={4}>
             <Row className="g-4">
               <Col xl={7} lg={12}>
                 <div className="border rounded p-3 h-100">
@@ -1210,7 +1221,7 @@ const DealDetailModal = ({
                       variant="outline-secondary"
                       size="sm"
                       onClick={handleRefresh}
-                      disabled={isRefreshing}
+                      disabled={isRefreshing || isLoading}
                     >
                       {isRefreshing ? 'Actualizando…' : 'Actualizar desde Pipedrive'}
                     </Button>
@@ -1846,6 +1857,7 @@ const DealDetailModal = ({
               )}
             </div>
           </Stack>
+          )}
         </Modal.Body>
         <Modal.Footer className="justify-content-between">
           <div className="text-muted small">
@@ -1855,7 +1867,11 @@ const DealDetailModal = ({
             <Button variant="secondary" onClick={onHide}>
               Cerrar
             </Button>
-            <Button variant="primary" onClick={handleSaveSchedule} disabled={deal.trainingProducts.length === 0}>
+            <Button
+              variant="primary"
+              onClick={handleSaveSchedule}
+              disabled={isLoading || deal.trainingProducts.length === 0}
+            >
               Guardar en calendario
             </Button>
           </div>

--- a/src/services/deals.ts
+++ b/src/services/deals.ts
@@ -85,7 +85,7 @@ const normaliseDealRecords = (value: unknown): DealRecord[] => {
 };
 
 export const fetchDeals = async (): Promise<DealRecord[]> => {
-  const response = await fetch('/.netlify/functions/deals');
+  const response = await fetch('/.netlify/functions/deals?summary=1');
 
   if (!response.ok) {
     throw new Error(await parseErrorMessage(response));


### PR DESCRIPTION
## Summary
- add a summary mode to the deals Netlify function that skips per-deal notes/files and only loads minimal product data
- request the summary mode from the deals service and fetch full deal details before showing the modal in the board
- allow the deal modal to render a loading spinner until the detailed record arrives while keeping refresh logic intact

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1af55797c832885f65eb8bafe684b