### PR TITLE
Add loading state support to DealDetailModal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -175,7 +175,7 @@ const App = () => {
         </Modal>
       )}
 
-      {isCalendarModalOpen && calendarModalStatus === 'success' && selectedCalendarDeal && (
+      {isCalendarModalOpen && selectedCalendarDeal && (
         <DealDetailModal
           show
           deal={selectedCalendarDeal}
@@ -183,6 +183,7 @@ const App = () => {
           events={calendarEvents}
           onUpdateSchedule={handleUpdateSchedule}
           onDealRefetch={handleCalendarDealRefetch}
+          isLoading={calendarModalStatus === 'loading'}
         />
       )}
     </div>

--- a/src/components/deals/DealDetailModal.tsx
+++ b/src/components/deals/DealDetailModal.tsx
@@ -27,6 +27,7 @@ interface DealDetailModalProps {
   onHide: () => void;
   onUpdateSchedule: (dealId: number, events: CalendarEvent[]) => void;
   onDealRefetch: () => Promise<void> | void;
+  isLoading: boolean;
 }
 
 interface SessionFormEntry {
@@ -410,7 +411,8 @@ const DealDetailModal = ({
   events,
   onHide,
   onUpdateSchedule,
-  onDealRefetch
+  onDealRefetch,
+  isLoading
 }: DealDetailModalProps) => {
   const [localNotes, setLocalNotes] = useState<StoredDealNote[]>([]);
   const [localDocuments, setLocalDocuments] = useState<StoredDealDocument[]>([]);
@@ -432,6 +434,7 @@ const DealDetailModal = ({
   const [saveFeedback, setSaveFeedback] = useState<string | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const isBusy = isLoading || isRefreshing;
   const [mapVisible, setMapVisible] = useState(false);
   const [notesExpanded, setNotesExpanded] = useState(true);
   const [attachmentsExpanded, setAttachmentsExpanded] = useState(true);
@@ -877,6 +880,10 @@ const DealDetailModal = ({
   };
 
   const handleSaveSchedule = () => {
+    if (isBusy) {
+      return;
+    }
+
     setSaveError(null);
     setSaveFeedback(null);
 
@@ -1129,6 +1136,10 @@ const DealDetailModal = ({
   };
 
   const handleRefresh = async () => {
+    if (isLoading || isRefreshing) {
+      return;
+    }
+
     try {
       setIsRefreshing(true);
       await onDealRefetch();
@@ -1200,7 +1211,22 @@ const DealDetailModal = ({
           </div>
         </Modal.Header>
         <Modal.Body>
-          <Stack gap={4}>
+          <div className="position-relative">
+            {isLoading ? (
+              <div
+                className="position-absolute top-0 start-0 w-100 h-100 d-flex flex-column justify-content-center align-items-center bg-white bg-opacity-75"
+                style={{ zIndex: 1 }}
+                aria-live="polite"
+              >
+                <div className="spinner-border" role="status" aria-hidden="true" />
+                <div className="mt-3">Cargando presupuesto...</div>
+              </div>
+            ) : null}
+            <Stack
+              gap={4}
+              aria-busy={isLoading}
+              style={isLoading ? { pointerEvents: 'none', userSelect: 'none' } : undefined}
+            >
             <Row className="g-4">
               <Col xl={7} lg={12}>
                 <div className="border rounded p-3 h-100">
@@ -1210,9 +1236,13 @@ const DealDetailModal = ({
                       variant="outline-secondary"
                       size="sm"
                       onClick={handleRefresh}
-                      disabled={isRefreshing}
+                      disabled={isBusy}
                     >
-                      {isRefreshing ? 'Actualizando…' : 'Actualizar desde Pipedrive'}
+                      {isRefreshing
+                        ? 'Actualizando…'
+                        : isLoading
+                          ? 'Cargando…'
+                          : 'Actualizar desde Pipedrive'}
                     </Button>
                 </div>
                   <Stack gap={3}>
@@ -1846,8 +1876,9 @@ const DealDetailModal = ({
               )}
             </div>
           </Stack>
-        </Modal.Body>
-        <Modal.Footer className="justify-content-between">
+        </div>
+      </Modal.Body>
+      <Modal.Footer className="justify-content-between">
           <div className="text-muted small">
             Los cambios se guardan en el calendario interno de planificación.
           </div>
@@ -1855,7 +1886,11 @@ const DealDetailModal = ({
             <Button variant="secondary" onClick={onHide}>
               Cerrar
             </Button>
-            <Button variant="primary" onClick={handleSaveSchedule} disabled={deal.trainingProducts.length === 0}>
+            <Button
+              variant="primary"
+              onClick={handleSaveSchedule}
+              disabled={isBusy || deal.trainingProducts.length === 0}
+            >
               Guardar en calendario
             </Button>
           </div>

--- a/src/components/deals/DealsBoard.tsx
+++ b/src/components/deals/DealsBoard.tsx
@@ -906,6 +906,7 @@ const DealsBoard = ({ events, onUpdateSchedule }: DealsBoardProps) => {
               console.error('No se pudo actualizar el deal seleccionado', refreshError);
             }
           }}
+          isLoading={false}
         />
       )}
     </>


### PR DESCRIPTION
## Summary
- add an `isLoading` prop to `DealDetailModal` so the modal can render a loading overlay and disable actions while data is fetched
- guard refresh/save handlers and button states with the loading flag to prevent concurrent requests
- update the calendar view and deals board to pass the appropriate loading state to the modal

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1b521a58c83288a4096fb4b56dc6f