### PR TITLE
Remove hidden deals from calendar when removed from backlog

### DIFF
--- a/src/components/deals/DealsBoard.tsx
+++ b/src/components/deals/DealsBoard.tsx
@@ -647,6 +647,8 @@ const DealsBoard = ({ events, onUpdateSchedule }: DealsBoardProps) => {
       return;
     }
 
+    const hadScheduledEvents = events.some((event) => event.dealId === dealId);
+
     setHiddenDealIds((previous) => {
       if (previous.includes(dealId)) {
         return previous;
@@ -663,9 +665,15 @@ const DealsBoard = ({ events, onUpdateSchedule }: DealsBoardProps) => {
       return current.filter((item) => item.id !== dealId);
     });
 
+    if (hadScheduledEvents) {
+      onUpdateSchedule(dealId, []);
+    }
+
     setFeedback({
       type: 'success',
-      message: `Presupuesto #${dealId} eliminado de la lista.`
+      message: hadScheduledEvents
+        ? `Presupuesto #${dealId} eliminado de la lista y del calendario.`
+        : `Presupuesto #${dealId} eliminado de la lista.`
     });
   };
 


### PR DESCRIPTION
## Summary
- remove scheduled calendar events when a deal is hidden from the backlog list
- update the confirmation feedback to reflect when calendar entries were cleared

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d39892cd008328847d70c488b5a850