### PR TITLE
Add calendar filters matching budget fields

### DIFF
--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useMemo, useState } from 'react';
 import type { EventClickArg } from '@fullcalendar/core';
 import FullCalendar from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid';
@@ -5,13 +6,126 @@ import timeGridPlugin from '@fullcalendar/timegrid';
 import listPlugin from '@fullcalendar/list';
 import interactionPlugin from '@fullcalendar/interaction';
 import esLocale from '@fullcalendar/core/locales/es';
+import Badge from 'react-bootstrap/Badge';
+import Button from 'react-bootstrap/Button';
 import Card from 'react-bootstrap/Card';
+import Collapse from 'react-bootstrap/Collapse';
+import Col from 'react-bootstrap/Col';
+import Form from 'react-bootstrap/Form';
+import Row from 'react-bootstrap/Row';
 import { CalendarEvent } from '../../services/calendar';
 
 interface CalendarViewProps {
   events: CalendarEvent[];
   onSelectEvent?: (event: CalendarEvent) => void;
 }
+
+type FilterKey =
+  | 'id'
+  | 'title'
+  | 'clientName'
+  | 'formations'
+  | 'fundae'
+  | 'caes'
+  | 'hotelPernocta'
+  | 'sede'
+  | 'address'
+  | 'trainer'
+  | 'mobileUnit';
+
+type CalendarFilters = Record<FilterKey, string>;
+
+type FilterInputType = 'text' | 'select';
+
+interface FilterOption {
+  value: string;
+  label: string;
+}
+
+interface FilterDefinition {
+  key: FilterKey;
+  label: string;
+  placeholder?: string;
+  type: FilterInputType;
+  options?: FilterOption[];
+}
+
+const filterRows: FilterKey[][] = [
+  ['id', 'clientName', 'title', 'formations'],
+  ['fundae', 'caes', 'hotelPernocta', 'sede'],
+  ['address', 'trainer', 'mobileUnit']
+];
+
+const filterKeys: FilterKey[] = [
+  'id',
+  'clientName',
+  'title',
+  'formations',
+  'fundae',
+  'caes',
+  'hotelPernocta',
+  'sede',
+  'address',
+  'trainer',
+  'mobileUnit'
+];
+
+const createEmptyFilters = (): CalendarFilters =>
+  filterKeys.reduce((accumulator, key) => {
+    accumulator[key] = '';
+    return accumulator;
+  }, {} as CalendarFilters);
+
+const createYesNoOptions = (allLabel: string): FilterOption[] => [
+  { value: '', label: allLabel },
+  { value: 'si', label: 'Sí' },
+  { value: 'no', label: 'No' }
+];
+
+const fundaeSelectOptions = createYesNoOptions('Todas las opciones');
+const caesSelectOptions = createYesNoOptions('Todas las opciones');
+const hotelPernoctaSelectOptions = createYesNoOptions('Todas las opciones');
+
+const sedeSelectOptions: FilterOption[] = [
+  { value: '', label: 'Todas las sedes' },
+  { value: 'GEP Arganda', label: 'GEP Arganda' },
+  { value: 'GEP Sabadell', label: 'GEP Sabadell' },
+  { value: 'In Company', label: 'In Company' }
+];
+
+const fallbackClientName = 'Sin organización asociada';
+const fallbackSede = 'Sin sede definida';
+const fallbackFormationsLabel = 'Sin formaciones form-';
+
+const normaliseText = (value: string): string =>
+  value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLocaleLowerCase('es');
+
+const buildUniqueList = (values: string[]): string[] => {
+  const map = new Map<string, string>();
+
+  values.forEach((value) => {
+    if (typeof value !== 'string') {
+      return;
+    }
+
+    const trimmed = value.trim();
+
+    if (trimmed.length === 0) {
+      return;
+    }
+
+    const normalized = normaliseText(trimmed);
+
+    if (!map.has(normalized)) {
+      map.set(normalized, trimmed);
+    }
+  });
+
+  return Array.from(map.values());
+};
 
 const buildEventTitle = (event: CalendarEvent) => {
   const segments = [event.productName];
@@ -41,60 +155,340 @@ const buildEventTitle = (event: CalendarEvent) => {
   return segments.join(' · ');
 };
 
-const CalendarView = ({ events, onSelectEvent }: CalendarViewProps) => (
-  <Card className="calendar-card border-0">
-    <Card.Body className="p-0">
-      <div className="calendar-scroll-container">
-        <FullCalendar
-          plugins={[dayGridPlugin, timeGridPlugin, listPlugin, interactionPlugin]}
-          initialView="timeGridWeek"
-          headerToolbar={{
-            left: 'prev,next today',
-            center: 'title',
-            right: 'dayGridMonth,timeGridWeek,timeGridDay,listWeek'
-          }}
-          weekends
-          selectable={false}
-          editable={false}
-          slotDuration="00:30:00"
-          slotMinTime="00:00:00"
-          scrollTime="06:00:00"
-          height="parent"
-          nowIndicator
-          events={events.map((event) => ({
-            id: event.id,
-            title: buildEventTitle(event),
-            start: event.start,
-            end: event.end,
-            extendedProps: {
-              dealId: event.dealId,
-              dealTitle: event.dealTitle,
-              productName: event.productName,
-              attendees: event.attendees,
-              sede: event.sede,
-              address: event.address,
-              trainers: event.trainers,
-              mobileUnits: event.mobileUnits,
-              logisticsInfo: event.logisticsInfo
-            }
-          }))}
-          eventClick={(info: EventClickArg) => {
-            if (!onSelectEvent) {
-              return;
-            }
+const CalendarView = ({ events, onSelectEvent }: CalendarViewProps) => {
+  const [filtersExpanded, setFiltersExpanded] = useState(false);
+  const [filters, setFilters] = useState<CalendarFilters>(() => createEmptyFilters());
+  const filterPanelId = 'calendar-filters-panel';
 
-            const calendarEvent = events.find((item) => item.id === info.event.id);
+  const availableTrainers = useMemo(() => {
+    const values: string[] = [];
 
-            if (calendarEvent) {
-              onSelectEvent(calendarEvent);
-            }
-          }}
-          locales={[esLocale]}
-          locale="es"
-        />
-      </div>
-    </Card.Body>
-  </Card>
-);
+    events.forEach((event) => {
+      values.push(...event.trainers);
+    });
+
+    const unique = buildUniqueList(values);
+    unique.sort((first, second) => first.localeCompare(second, 'es', { sensitivity: 'base' }));
+    return unique;
+  }, [events]);
+
+  const availableMobileUnits = useMemo(() => {
+    const values: string[] = [];
+
+    events.forEach((event) => {
+      values.push(...event.mobileUnits);
+    });
+
+    const unique = buildUniqueList(values);
+    unique.sort((first, second) => first.localeCompare(second, 'es', { sensitivity: 'base' }));
+    return unique;
+  }, [events]);
+
+  const trainerOptions = useMemo<FilterOption[]>(() => {
+    const baseOption: FilterOption = { value: '', label: 'Todos los bomberos' };
+
+    if (availableTrainers.length === 0) {
+      return [baseOption];
+    }
+
+    return [baseOption, ...availableTrainers.map((trainer) => ({ value: trainer, label: trainer }))];
+  }, [availableTrainers]);
+
+  const mobileUnitOptions = useMemo<FilterOption[]>(() => {
+    const baseOption: FilterOption = { value: '', label: 'Todas las unidades móviles' };
+
+    if (availableMobileUnits.length === 0) {
+      return [baseOption];
+    }
+
+    return [baseOption, ...availableMobileUnits.map((unit) => ({ value: unit, label: unit }))];
+  }, [availableMobileUnits]);
+
+  const filterDefinitions = useMemo<Record<FilterKey, FilterDefinition>>(
+    () => ({
+      id: {
+        key: 'id',
+        label: 'Presupuesto',
+        placeholder: 'Ej. 1234',
+        type: 'text'
+      },
+      clientName: {
+        key: 'clientName',
+        label: 'Cliente',
+        placeholder: 'Nombre de la organización',
+        type: 'text'
+      },
+      title: {
+        key: 'title',
+        label: 'Título',
+        placeholder: 'Busca por título',
+        type: 'text'
+      },
+      formations: {
+        key: 'formations',
+        label: 'Formación',
+        placeholder: 'Formaciones vinculadas',
+        type: 'text'
+      },
+      fundae: {
+        key: 'fundae',
+        label: 'FUNDAE',
+        type: 'select',
+        options: fundaeSelectOptions
+      },
+      caes: {
+        key: 'caes',
+        label: 'CAES',
+        type: 'select',
+        options: caesSelectOptions
+      },
+      hotelPernocta: {
+        key: 'hotelPernocta',
+        label: 'Hotel Pernocta',
+        type: 'select',
+        options: hotelPernoctaSelectOptions
+      },
+      sede: {
+        key: 'sede',
+        label: 'Sede de la formación',
+        type: 'select',
+        options: sedeSelectOptions
+      },
+      address: {
+        key: 'address',
+        label: 'Dirección',
+        placeholder: 'Dirección de la formación',
+        type: 'text'
+      },
+      trainer: {
+        key: 'trainer',
+        label: 'Bombero',
+        type: 'select',
+        options: trainerOptions
+      },
+      mobileUnit: {
+        key: 'mobileUnit',
+        label: 'Unidades móviles',
+        type: 'select',
+        options: mobileUnitOptions
+      }
+    }),
+    [mobileUnitOptions, trainerOptions]
+  );
+
+  const handleFilterChange = useCallback((key: FilterKey, value: string) => {
+    setFilters((previous) => ({ ...previous, [key]: value }));
+  }, []);
+
+  const handleResetFilters = useCallback(() => {
+    setFilters(createEmptyFilters());
+  }, []);
+
+  const getFilterFieldValue = useCallback((event: CalendarEvent, key: FilterKey): string => {
+    switch (key) {
+      case 'id':
+        return String(event.dealId);
+      case 'title':
+        return event.dealTitle ?? '';
+      case 'clientName':
+        return event.clientName ?? fallbackClientName;
+      case 'formations':
+        return event.formations.length > 0 ? event.formations.join(' ') : fallbackFormationsLabel;
+      case 'fundae':
+        return event.fundae ?? '';
+      case 'caes':
+        return event.caes ?? '';
+      case 'hotelPernocta':
+        return event.hotelPernocta ?? '';
+      case 'sede':
+        return event.sede ?? fallbackSede;
+      case 'address':
+        return event.address ?? '';
+      case 'trainer':
+        return event.trainers.length > 0 ? event.trainers.join(' ') : '';
+      case 'mobileUnit':
+        return event.mobileUnits.length > 0 ? event.mobileUnits.join(' ') : '';
+      default:
+        return '';
+    }
+  }, []);
+
+  const normalizedFilters = useMemo(
+    () =>
+      (Object.entries(filters) as [FilterKey, string][])
+        .map(([key, value]) => [key, value.trim()] as [FilterKey, string])
+        .filter(([, value]) => value.length > 0)
+        .map(([key, value]) => [key, normaliseText(value)] as [FilterKey, string]),
+    [filters]
+  );
+
+  const activeFilterCount = normalizedFilters.length;
+  const isFiltering = activeFilterCount > 0;
+
+  const filteredEvents = useMemo<CalendarEvent[]>(() => {
+    if (events.length === 0) {
+      return [];
+    }
+
+    if (normalizedFilters.length === 0) {
+      return events;
+    }
+
+    return events.filter((event) =>
+      normalizedFilters.every(([key, filterValue]) => {
+        const haystack = normaliseText(getFilterFieldValue(event, key));
+        return haystack.includes(filterValue);
+      })
+    );
+  }, [events, normalizedFilters, getFilterFieldValue]);
+
+  const showEmptyState = isFiltering && filteredEvents.length === 0;
+
+  return (
+    <Card className="calendar-card border-0">
+      <Card.Body className="p-0">
+        <div className="d-flex justify-content-end mb-4">
+          <Button
+            variant={isFiltering ? 'primary' : 'outline-secondary'}
+            onClick={() => setFiltersExpanded((current) => !current)}
+            aria-expanded={filtersExpanded}
+            aria-controls={filterPanelId}
+          >
+            {filtersExpanded ? 'Ocultar filtros' : 'Mostrar filtros'}
+            {activeFilterCount > 0 && (
+              <Badge bg={isFiltering ? 'light' : 'secondary'} text={isFiltering ? 'dark' : undefined} className="ms-2">
+                {activeFilterCount}
+              </Badge>
+            )}
+          </Button>
+        </div>
+
+        <Collapse in={filtersExpanded}>
+          <div id={filterPanelId} className="mb-4">
+            <div className="border rounded p-3">
+              <Form>
+                <div className="d-flex flex-column gap-3">
+                  {filterRows.map((row, rowIndex) => {
+                    const columnSize = Math.floor(12 / row.length);
+
+                    return (
+                      <Row key={`filter-row-${rowIndex}`} className="g-3">
+                        {row.map((key) => {
+                          const definition = filterDefinitions[key];
+                          const columnWidth = Number.isFinite(columnSize) ? columnSize : 4;
+
+                          return (
+                            <Col key={key} lg={columnWidth} md={6} sm={12}>
+                              <Form.Group controlId={`calendar-filter-${key}`}>
+                                <Form.Label>{definition.label}</Form.Label>
+                                {definition.type === 'select' ? (
+                                  <Form.Select
+                                    value={filters[key]}
+                                    onChange={(event) => handleFilterChange(key, event.target.value)}
+                                  >
+                                    {(definition.options ?? [{ value: '', label: 'Todas las opciones' }]).map((option) => (
+                                      <option key={`${key}-${option.value || 'all'}`} value={option.value}>
+                                        {option.label}
+                                      </option>
+                                    ))}
+                                  </Form.Select>
+                                ) : (
+                                  <Form.Control
+                                    type="text"
+                                    value={filters[key]}
+                                    placeholder={definition.placeholder}
+                                    onChange={(event) => handleFilterChange(key, event.target.value)}
+                                  />
+                                )}
+                              </Form.Group>
+                            </Col>
+                          );
+                        })}
+                      </Row>
+                    );
+                  })}
+                </div>
+                <div className="d-flex justify-content-end gap-2 mt-3">
+                  <Button
+                    type="button"
+                    variant="outline-secondary"
+                    onClick={handleResetFilters}
+                    disabled={!isFiltering}
+                  >
+                    Limpiar filtros
+                  </Button>
+                </div>
+              </Form>
+            </div>
+          </div>
+        </Collapse>
+
+        {showEmptyState && (
+          <div className="text-center text-secondary pb-3">
+            <p className="fw-semibold mb-1">No se encontraron eventos con los filtros aplicados.</p>
+            <Button variant="link" type="button" onClick={handleResetFilters} className="p-0">
+              Limpiar filtros
+            </Button>
+          </div>
+        )}
+
+        <div className="calendar-scroll-container">
+          <FullCalendar
+            plugins={[dayGridPlugin, timeGridPlugin, listPlugin, interactionPlugin]}
+            initialView="timeGridWeek"
+            headerToolbar={{
+              left: 'prev,next today',
+              center: 'title',
+              right: 'dayGridMonth,timeGridWeek,timeGridDay,listWeek'
+            }}
+            weekends
+            selectable={false}
+            editable={false}
+            slotDuration="00:30:00"
+            slotMinTime="00:00:00"
+            scrollTime="06:00:00"
+            height="parent"
+            nowIndicator
+            events={filteredEvents.map((event) => ({
+              id: event.id,
+              title: buildEventTitle(event),
+              start: event.start,
+              end: event.end,
+              extendedProps: {
+                dealId: event.dealId,
+                dealTitle: event.dealTitle,
+                productName: event.productName,
+                attendees: event.attendees,
+                sede: event.sede,
+                address: event.address,
+                trainers: event.trainers,
+                mobileUnits: event.mobileUnits,
+                logisticsInfo: event.logisticsInfo,
+                clientName: event.clientName,
+                formations: event.formations,
+                fundae: event.fundae,
+                caes: event.caes,
+                hotelPernocta: event.hotelPernocta
+              }
+            }))}
+            eventClick={(info: EventClickArg) => {
+              if (!onSelectEvent) {
+                return;
+              }
+
+              const calendarEvent = filteredEvents.find((item) => item.id === info.event.id);
+
+              if (calendarEvent) {
+                onSelectEvent(calendarEvent);
+              }
+            }}
+            locales={[esLocale]}
+            locale="es"
+          />
+        </div>
+      </Card.Body>
+    </Card>
+  );
+};
 
 export default CalendarView;

--- a/src/components/deals/DealDetailModal.tsx
+++ b/src/components/deals/DealDetailModal.tsx
@@ -182,6 +182,15 @@ const sanitizeSelectionList = (values: string[]): string[] =>
 
 const normalizeSelectionValue = (value: string): string => value.trim();
 
+const sanitizeOptionalDealText = (value: string | null | undefined): string | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
 const getDateKey = (date: Date): string => {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, '0');
@@ -901,6 +910,11 @@ const DealDetailModal = ({
     }
 
     const eventsToSave: CalendarEvent[] = [];
+    const sanitizedClientName = sanitizeOptionalDealText(deal.clientName);
+    const sanitizedFundae = sanitizeOptionalDealText(deal.fundae);
+    const sanitizedCaes = sanitizeOptionalDealText(deal.caes);
+    const sanitizedHotelPernocta = sanitizeOptionalDealText(deal.hotelPernocta);
+    const sanitizedFormations = sanitizeSelectionList(deal.formations);
 
     for (const session of sessions) {
       const startIso = toIsoString(session.start);
@@ -921,6 +935,7 @@ const DealDetailModal = ({
         id: `deal-${deal.id}-item-${session.dealProductId}-session-${session.sessionIndex}`,
         dealId: deal.id,
         dealTitle: deal.title,
+        clientName: sanitizedClientName,
         dealProductId: session.dealProductId,
         productId: session.productId,
         productName: session.productName,
@@ -932,6 +947,10 @@ const DealDetailModal = ({
         address: session.address.trim() ? session.address.trim() : null,
         trainers: sanitizedTrainers,
         mobileUnits: sanitizedMobileUnits,
+        formations: sanitizedFormations,
+        fundae: sanitizedFundae,
+        caes: sanitizedCaes,
+        hotelPernocta: sanitizedHotelPernocta,
         logisticsInfo: logisticsInfo ? logisticsInfo : null
       });
     }

--- a/src/services/calendar.ts
+++ b/src/services/calendar.ts
@@ -2,6 +2,7 @@ export interface CalendarEvent {
   id: string;
   dealId: number;
   dealTitle: string;
+  clientName: string | null;
   dealProductId: number;
   productId: number | null;
   productName: string;
@@ -13,6 +14,10 @@ export interface CalendarEvent {
   address: string | null;
   trainers: string[];
   mobileUnits: string[];
+  formations: string[];
+  fundae: string | null;
+  caes: string | null;
+  hotelPernocta: string | null;
   logisticsInfo: string | null;
 }
 
@@ -82,6 +87,7 @@ const sanitizeCalendarEvent = (event: StoredCalendarEvent): CalendarEvent => {
     id: event.id,
     dealId: event.dealId,
     dealTitle: parseString(event.dealTitle),
+    clientName: parseOptionalString((event as { clientName?: unknown }).clientName),
     dealProductId: parseNumber(event.dealProductId, 0),
     productId: parseOptionalNumber(event.productId),
     productName: parseString(event.productName),
@@ -93,6 +99,10 @@ const sanitizeCalendarEvent = (event: StoredCalendarEvent): CalendarEvent => {
     address: parseOptionalString(event.address),
     trainers,
     mobileUnits,
+    formations: sanitizeStringArray((event as { formations?: unknown }).formations),
+    fundae: parseOptionalString((event as { fundae?: unknown }).fundae),
+    caes: parseOptionalString((event as { caes?: unknown }).caes),
+    hotelPernocta: parseOptionalString((event as { hotelPernocta?: unknown }).hotelPernocta),
     logisticsInfo: parseOptionalString(event.logisticsInfo)
   };
 };


### PR DESCRIPTION
## Summary
- add a collapsible filters panel to the calendar view with the same fields used in the budgets tab
- store additional deal metadata on calendar events so filters can target client, FUNDAE, CAES, hotel, and formations information
- include the extra metadata when persisting sessions from the deal detail modal to keep calendar data in sync

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d399b9ec588328b50b71f9126a72e2