### PR TITLE
feat: add session state controls and visuals

### DIFF
--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -13,7 +13,12 @@ import Collapse from 'react-bootstrap/Collapse';
 import Col from 'react-bootstrap/Col';
 import Form from 'react-bootstrap/Form';
 import Row from 'react-bootstrap/Row';
-import { CalendarEvent } from '../../services/calendar';
+import {
+  CalendarEvent,
+  getSessionDisplayState,
+  getSessionStateColors,
+  getSessionStateLabel
+} from '../../services/calendar';
 
 interface CalendarViewProps {
   events: CalendarEvent[];
@@ -449,28 +454,40 @@ const CalendarView = ({ events, onSelectEvent }: CalendarViewProps) => {
             scrollTime="06:00:00"
             height="parent"
             nowIndicator
-            events={filteredEvents.map((event) => ({
-              id: event.id,
-              title: buildEventTitle(event),
-              start: event.start,
-              end: event.end,
-              extendedProps: {
-                dealId: event.dealId,
-                dealTitle: event.dealTitle,
-                productName: event.productName,
-                attendees: event.attendees,
-                sede: event.sede,
-                address: event.address,
-                trainers: event.trainers,
-                mobileUnits: event.mobileUnits,
-                logisticsInfo: event.logisticsInfo,
-                clientName: event.clientName,
-                formations: event.formations,
-                fundae: event.fundae,
-                caes: event.caes,
-                hotelPernocta: event.hotelPernocta
-              }
-            }))}
+            events={filteredEvents.map((event) => {
+              const displayState = getSessionDisplayState(event);
+              const stateColors = getSessionStateColors(displayState);
+              const stateLabel = getSessionStateLabel(displayState);
+
+              return {
+                id: event.id,
+                title: buildEventTitle(event),
+                start: event.start,
+                end: event.end,
+                backgroundColor: stateColors.background,
+                borderColor: stateColors.border,
+                textColor: stateColors.text,
+                extendedProps: {
+                  dealId: event.dealId,
+                  dealTitle: event.dealTitle,
+                  productName: event.productName,
+                  attendees: event.attendees,
+                  sede: event.sede,
+                  address: event.address,
+                  trainers: event.trainers,
+                  mobileUnits: event.mobileUnits,
+                  logisticsInfo: event.logisticsInfo,
+                  clientName: event.clientName,
+                  formations: event.formations,
+                  fundae: event.fundae,
+                  caes: event.caes,
+                  hotelPernocta: event.hotelPernocta,
+                  manualState: event.manualState,
+                  state: displayState,
+                  stateLabel
+                }
+              };
+            })}
             eventClick={(info: EventClickArg) => {
               if (!onSelectEvent) {
                 return;


### PR DESCRIPTION
## Summary
- add shared session status helpers, color mappings, and manual state support for calendar events
- surface manual state controls, subtle status styling, and relaxed conflict checks for inactive sessions in the deal modal
- color-code calendar entries and expose state metadata based on the derived session status

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3a892a4a88328bf2997ba33c35a23