### PR TITLE
Fix ReferenceError when opening presupuesto tab

### DIFF
--- a/src/components/deals/DealsBoard.tsx
+++ b/src/components/deals/DealsBoard.tsx
@@ -183,21 +183,6 @@ const DealsBoard = ({ events, onUpdateSchedule }: DealsBoardProps) => {
   });
 
   useEffect(() => {
-    if (!data || data.length === 0) {
-      return;
-    }
-
-    setManualDeals((previous) =>
-      previous.filter(
-        (manualDeal) =>
-          !data.some(
-            (dealItem) => dealItem.id === manualDeal.id && hasPendingSessions(dealItem)
-          )
-      )
-    );
-  }, [data, hasPendingSessions]);
-
-  useEffect(() => {
     persistStoredManualDeals(manualDeals);
   }, [manualDeals]);
 
@@ -282,6 +267,21 @@ const DealsBoard = ({ events, onUpdateSchedule }: DealsBoardProps) => {
     },
     [scheduledSessionsByKey]
   );
+
+  useEffect(() => {
+    if (!data || data.length === 0) {
+      return;
+    }
+
+    setManualDeals((previous) =>
+      previous.filter(
+        (manualDeal) =>
+          !data.some(
+            (dealItem) => dealItem.id === manualDeal.id && hasPendingSessions(dealItem)
+          )
+      )
+    );
+  }, [data, hasPendingSessions]);
 
   const dealsWithManual = useMemo<DealRecord[]>(() => {
     const map = new Map<number, DealRecord>();


### PR DESCRIPTION
## Summary
- move the manual deal cleanup effect to execute after the hasPendingSessions callback is defined to avoid temporal dead zone access
- ensure presupuesto tab renders without triggering ReferenceError during initialization

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3d5f16f908328bf87bcce1647f3d2