### PR TITLE
Fix schedule modal close callbacks initialization order

### DIFF
--- a/src/components/deals/DealDetailModal.tsx
+++ b/src/components/deals/DealDetailModal.tsx
@@ -660,24 +660,6 @@ const DealDetailModal = ({
     closeDocumentModal();
   }, [closeDocumentModal, isDocumentDirty]);
 
-  const handleScheduleModalCloseRequest = useCallback(() => {
-    if (hasScheduleChanges) {
-      setShowScheduleUnsavedConfirm(true);
-      return;
-    }
-
-    onHide();
-  }, [hasScheduleChanges, onHide]);
-
-  const handleKeepEditingSchedule = useCallback(() => {
-    setShowScheduleUnsavedConfirm(false);
-  }, []);
-
-  const handleConfirmScheduleDiscard = useCallback(() => {
-    setShowScheduleUnsavedConfirm(false);
-    onHide();
-  }, [onHide]);
-
   const eventsByKey = useMemo(() => {
     const map = new Map<string, CalendarEvent>();
     events
@@ -779,6 +761,24 @@ const DealDetailModal = ({
     [sessions, caesValue, fundaeValue, hotelPernoctaValue]
   );
   const hasScheduleChanges = currentScheduleSnapshot !== scheduleBaseline;
+
+  const handleScheduleModalCloseRequest = useCallback(() => {
+    if (hasScheduleChanges) {
+      setShowScheduleUnsavedConfirm(true);
+      return;
+    }
+
+    onHide();
+  }, [hasScheduleChanges, onHide]);
+
+  const handleKeepEditingSchedule = useCallback(() => {
+    setShowScheduleUnsavedConfirm(false);
+  }, []);
+
+  const handleConfirmScheduleDiscard = useCallback(() => {
+    setShowScheduleUnsavedConfirm(false);
+    onHide();
+  }, [onHide]);
 
   useEffect(() => {
     setSessions(initialSessions);


### PR DESCRIPTION
## Summary
- define schedule modal close callbacks after computing `hasScheduleChanges` to avoid temporal dead zone errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d44632660c83289f746072f6d08c59