### PR TITLE
Update session date validation message

### DIFF
--- a/src/components/deals/DealDetailModal.tsx
+++ b/src/components/deals/DealDetailModal.tsx
@@ -1341,9 +1341,7 @@ const DealDetailModal = ({
       }
 
       if (endDate.getTime() < startDate.getTime()) {
-        setSaveError(
-          'Hay sesiones donde la fecha de fin es anterior a la fecha de inicio. Por favor avisa al comercial.'
-        );
+        setSaveError('Hay sesiones donde la fecha de fin es anterior a la fecha de inicio.');
         return;
       }
 


### PR DESCRIPTION
## Summary
- simplify the validation error message for sessions where the end date precedes the start date

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d461dd340883288281978347fd31ac