### PR TITLE
Limit session sede choices to predefined options

### DIFF
--- a/src/components/deals/DealDetailModal.tsx
+++ b/src/components/deals/DealDetailModal.tsx
@@ -101,6 +101,9 @@ const DOCUMENT_EXTENSIONS = new Set([
   'csv'
 ]);
 
+const SESSION_SEDE_OPTIONS = ['GEP Arganda', 'GEP Sabadell', 'In Company'] as const;
+const SESSION_SEDE_OPTION_SET = new Set<string>(SESSION_SEDE_OPTIONS);
+
 const extractExtension = (value: string | null | undefined): string | null => {
   if (typeof value !== 'string' || value.length === 0) {
     return null;
@@ -2238,13 +2241,29 @@ const DealDetailModal = ({
                                         <Col md={6}>
                                           <Form.Group controlId={`sede-${session.key}`}>
                                             <Form.Label>Sede</Form.Label>
-                                            <Form.Control
-                                              type="text"
+                                            <Form.Select
                                               value={session.sede}
                                               onChange={(event) =>
                                                 handleSessionFieldChange(session.key, 'sede', event.target.value)
                                               }
-                                            />
+                                            >
+                                              {session.sede === '' ? (
+                                                <option value="" disabled hidden>
+                                                  Selecciona una sede
+                                                </option>
+                                              ) : (
+                                                <option value="">Sin sede</option>
+                                              )}
+                                              {SESSION_SEDE_OPTIONS.map((option) => (
+                                                <option key={option} value={option}>
+                                                  {option}
+                                                </option>
+                                              ))}
+                                              {session.sede !== '' &&
+                                              !SESSION_SEDE_OPTION_SET.has(session.sede) ? (
+                                                <option value={session.sede}>{session.sede}</option>
+                                              ) : null}
+                                            </Form.Select>
                                           </Form.Group>
                                         </Col>
                                         <Col xs={12}>


### PR DESCRIPTION
## Summary
- replace the session sede free text input with a select dropdown
- limit selectable options to GEP Arganda, GEP Sabadell, or In Company while keeping existing values visible

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4eb59bd688328b91676dca77e5fdb