### PR TITLE
Autocompleta horas de formación en los popups

### DIFF
--- a/src/components/deals/DealDetailModal.tsx
+++ b/src/components/deals/DealDetailModal.tsx
@@ -35,6 +35,7 @@ import {
   StoredDealDocument,
   StoredDealNote
 } from '../../services/dealExtras';
+import { resolveFormationRecommendedHoursFromList } from '../../data/formationRecommendedHours';
 
 interface DealDetailModalProps {
   show: boolean;
@@ -699,6 +700,37 @@ const DealDetailModal = ({
     [deal.formations, trainingProducts]
   );
 
+  const recommendedHoursMetadata = useMemo(() => {
+    const map = new Map<number, { numeric: number | null; raw: string | null }>();
+    const formationCandidates = formationLabels;
+
+    trainingProducts.forEach((product) => {
+      let numeric = product.recommendedHours ?? null;
+      let raw =
+        product.recommendedHoursRaw ?? (numeric != null ? String(numeric) : null);
+
+      if (numeric == null) {
+        const resolved = resolveFormationRecommendedHoursFromList([
+          product.recommendedHoursRaw,
+          product.name,
+          product.code,
+          ...formationCandidates
+        ]);
+
+        if (resolved != null) {
+          numeric = resolved;
+          if (!raw) {
+            raw = `${resolved} horas`;
+          }
+        }
+      }
+
+      map.set(product.dealProductId, { numeric, raw });
+    });
+
+    return map;
+  }, [formationLabels, trainingProducts]);
+
   const productMap = useMemo(() => {
     const byDealProductId = new Map<number, string>();
     const byProductId = new Map<number, string>();
@@ -832,13 +864,17 @@ const DealDetailModal = ({
               ? [legacyMobileUnit.trim()]
               : [];
 
+        const recommended = recommendedHoursMetadata.get(product.dealProductId);
+        const recommendedHours = recommended?.numeric ?? product.recommendedHours ?? null;
+        const recommendedHoursRaw = recommended?.raw ?? product.recommendedHoursRaw ?? null;
+
         return {
           key,
           dealProductId: product.dealProductId,
           productId: product.productId,
           productName: product.name,
-          recommendedHours: product.recommendedHours,
-          recommendedHoursRaw: product.recommendedHoursRaw,
+          recommendedHours,
+          recommendedHoursRaw,
           sessionIndex: index,
           start: formatDateTimeInput(existingEvent?.start),
           end: formatDateTimeInput(existingEvent?.end),
@@ -854,7 +890,7 @@ const DealDetailModal = ({
         } satisfies SessionFormEntry;
       });
     });
-  }, [deal.address, deal.sede, eventsByKey, trainingProducts]);
+  }, [deal.address, deal.sede, eventsByKey, recommendedHoursMetadata, trainingProducts]);
 
   const [sessions, setSessions] = useState<SessionFormEntry[]>(initialSessions);
 
@@ -876,13 +912,16 @@ const DealDetailModal = ({
   );
 
   const initialRecommendedHoursByProduct = useMemo(() => {
-    const entries = trainingProducts.map((product) => [
-      product.dealProductId,
-      product.recommendedHours != null ? String(product.recommendedHours) : ''
-    ]);
+    const entries = trainingProducts.map((product) => {
+      const recommended = recommendedHoursMetadata.get(product.dealProductId);
+      const numeric = recommended?.numeric ?? product.recommendedHours ?? null;
+      const value = numeric != null ? String(numeric) : '';
+
+      return [product.dealProductId, value];
+    });
 
     return Object.fromEntries(entries) as Record<number, string>;
-  }, [trainingProducts]);
+  }, [recommendedHoursMetadata, trainingProducts]);
 
   const [recommendedHoursByProduct, setRecommendedHoursByProduct] = useState(
     initialRecommendedHoursByProduct
@@ -929,6 +968,12 @@ const DealDetailModal = ({
     setSessions(initialSessions);
     setSessionWarnings({});
   }, [initialSessions, show]);
+
+  useEffect(() => {
+    if (show) {
+      setRecommendedHoursByProduct(initialRecommendedHoursByProduct);
+    }
+  }, [initialRecommendedHoursByProduct, show]);
 
   useEffect(() => {
     if (show) {
@@ -2139,6 +2184,12 @@ const DealDetailModal = ({
                   {trainingProducts.map((product) => {
                     const productSessions = sessions.filter((session) => session.dealProductId === product.dealProductId);
                     const sessionCount = countSessionsForProduct(product);
+                    const recommendedInfo = recommendedHoursMetadata.get(product.dealProductId);
+                    const recommendedDisplay =
+                      recommendedInfo?.raw ??
+                      (recommendedInfo?.numeric != null
+                        ? `${recommendedInfo.numeric} horas`
+                        : product.recommendedHoursRaw ?? null);
                     return (
                       <div key={`calendar-${product.dealProductId}`} className="border rounded p-3">
                         <div className="d-flex justify-content-between align-items-center mb-3">
@@ -2146,7 +2197,7 @@ const DealDetailModal = ({
                             <div className="fw-semibold">{product.name}</div>
                             <div className="text-muted small">
                               {sessionCount} sesión{sessionCount === 1 ? '' : 'es'} ·{' '}
-                              {product.recommendedHoursRaw ?? 'Horas recomendadas no disponibles'}
+                              {recommendedDisplay ?? 'Horas recomendadas no disponibles'}
                             </div>
                           </div>
                         </div>

--- a/src/data/formationRecommendedHours.ts
+++ b/src/data/formationRecommendedHours.ts
@@ -1,0 +1,149 @@
+const normalizeFormationLabel = (value: string): string =>
+  value
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+
+const formationHoursEntries: Array<[string, number]> = [
+  ['Uso de extintores portátiles', 4],
+  ['Formación uso de extintores', 4],
+  ['Extintores y agentes extintores', 4],
+  ['Formación básica contra incendios', 8],
+  ['Formación avanzada contra incendios', 16],
+  ['Formación reciclaje contra incendios', 4],
+  ['Lucha contra incendios nivel básico', 8],
+  ['Lucha contra incendios nivel medio', 12],
+  ['Lucha contra incendios nivel avanzado', 16],
+  ['Autoprotección y emergencias', 8],
+  ['Plan de autoprotección', 12],
+  ['Planes de autoprotección', 12],
+  ['Simulacro de emergencia', 4],
+  ['Simulacros de emergencia', 4],
+  ['BIEs y mangueras', 4],
+  ['Manejo de BIE', 4],
+  ['Equipos de emergencia BIE', 4],
+  ['Equipo de intervención', 8],
+  ['Equipos de intervención', 8],
+  ['ERA (equipo de respiración autónoma)', 8],
+  ['Equipos de respiración autónoma', 8],
+  ['Prácticas ERA', 6],
+  ['Espacios confinados', 8],
+  ['Trabajos en altura', 8],
+  ['Rescate en altura', 12],
+  ['Rescate vertical', 12],
+  ['Rescate en espacios confinados', 12],
+  ['Prevención de riesgos en altura', 6],
+  ['Primeros auxilios', 6],
+  ['Primeros auxilios avanzados', 8],
+  ['Primeros auxilios y DEA', 8],
+  ['Desfibrilador DEA', 4],
+  ['Riesgo eléctrico', 6],
+  ['Prevención de riesgos eléctricos', 6],
+  ['Carretillas elevadoras', 8],
+  ['Carretillas elevadoras y plataforma elevadora', 12],
+  ['Plataformas elevadoras móviles de personal', 8],
+  ['Grúa puente', 8],
+  ['Operador de grúa puente', 8],
+  ['Manipulación de mercancías peligrosas', 12],
+  ['Materiales peligrosos', 12],
+  ['Control de derrames de hidrocarburos', 8],
+  ['Plan de evacuación', 4],
+  ['Planes de evacuación', 4],
+  ['Investigación de incendios', 8],
+  ['Puesto de mando avanzado', 6],
+  ['Comunicaciones de emergencia', 4],
+  ['Incendios industriales', 12],
+  ['Incendios forestales', 12],
+  ['Uso de hidrantes', 4],
+  ['Logística de emergencias', 6]
+];
+
+const patternRules: Array<{ pattern: RegExp; hours: number }> = [
+  { pattern: /\breciclaj/, hours: 4 },
+  { pattern: /\bbasi(?:co|ca)\b/, hours: 8 },
+  { pattern: /\bavanzad/, hours: 16 },
+  { pattern: /\brefresc/, hours: 4 },
+  { pattern: /\bintroductori/, hours: 4 },
+  { pattern: /espacios?\s+confinad/, hours: 8 },
+  { pattern: /altura/, hours: 8 },
+  { pattern: /rescate/, hours: 12 },
+  { pattern: /primeros?\s+auxilio/, hours: 6 },
+  { pattern: /desfibrilador|dea/, hours: 4 },
+  { pattern: /extintor/, hours: 4 },
+  { pattern: /\bbie\b/, hours: 4 },
+  { pattern: /manguer/, hours: 4 },
+  { pattern: /autoproteccion/, hours: 8 },
+  { pattern: /plan\s+de\s+autoproteccion/, hours: 12 },
+  { pattern: /carretill/, hours: 8 },
+  { pattern: /plataforma\s+elevadora/, hours: 8 },
+  { pattern: /grua|puente\s+grua/, hours: 8 },
+  { pattern: /material(es)?\s+peligros/, hours: 12 },
+  { pattern: /riesg[oa]\s+electric/, hours: 6 },
+  { pattern: /hidrante/, hours: 4 }
+];
+
+const directHours = new Map<string, number>();
+formationHoursEntries.forEach(([label, hours]) => {
+  directHours.set(normalizeFormationLabel(label), hours);
+});
+
+const HOURS_LABEL_PATTERN = /(\d+(?:[.,]\d+)?)\s*(?:h|horas?|hrs?)/i;
+
+const extractHoursFromText = (value: string): number | null => {
+  const match = HOURS_LABEL_PATTERN.exec(value);
+  if (!match) {
+    return null;
+  }
+
+  const parsed = Number.parseFloat(match[1].replace(',', '.'));
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+export const resolveFormationRecommendedHours = (
+  value: string | null | undefined
+): number | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = normalizeFormationLabel(value);
+  if (!normalized) {
+    return null;
+  }
+
+  const direct = directHours.get(normalized);
+  if (direct !== undefined) {
+    return direct;
+  }
+
+  for (const rule of patternRules) {
+    if (rule.pattern.test(normalized)) {
+      return rule.hours;
+    }
+  }
+
+  return extractHoursFromText(value);
+};
+
+export const resolveFormationRecommendedHoursFromList = (
+  values: Array<string | null | undefined>
+): number | null => {
+  for (const value of values) {
+    const resolved = resolveFormationRecommendedHours(value);
+    if (resolved != null) {
+      return resolved;
+    }
+  }
+
+  return null;
+};
+
+export const formationRecommendedHoursCatalog = Object.freeze(
+  Array.from(directHours.entries()).reduce<Record<string, number>>((accumulator, [key, value]) => {
+    accumulator[key] = value;
+    return accumulator;
+  }, {})
+);
+


### PR DESCRIPTION
## Resumen
- añade un catálogo local de formaciones con sus horas recomendadas y utilidades de resolución
- precarga las horas sugeridas de cada producto en el popup usando el catálogo y actualiza la visualización

## Pruebas
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4ea9a7d3c8328ba4deb1ea3e05928