### PR TITLE
Avoid automatic Pipedrive sync on deal listing

### DIFF
--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -2615,8 +2615,8 @@ app.get("/deals", async (c) => {
 
   let deals = await listStoredDeals();
 
-  if (forceRefresh || deals.length === 0) {
-    await synchronizeDealsFromPipedrive({ force: forceRefresh, knownDeals: deals });
+  if (forceRefresh) {
+    await synchronizeDealsFromPipedrive({ force: true, knownDeals: deals });
     deals = await listStoredDeals();
   }
 


### PR DESCRIPTION
## Summary
- stop triggering the Neon persistence sync when listing deals without an explicit refresh request
- only sync with Pipedrive when the caller sets the refresh flag, keeping the database empty until a manual upload occurs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5107018448328843ce2fe07e961e9