### PR TITLE
Filtrar adjuntos sin deal asignado

### DIFF
--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -1641,7 +1641,7 @@ const parsePipedriveAttachments = (
 
     const resolvedDealId = resolveDealIdFromRecord(record);
     if (resolvedDealId === null) {
-      return true;
+      return false;
     }
 
     return resolvedDealId === expectedDealId;


### PR DESCRIPTION
## Summary
- evitar que la sincronización de deals incluya adjuntos sin `deal_id` cuando el deal esperado está definido
- garantizar que solo se muestren documentos reales provenientes de Pipedrive

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5164d82488328adcec9cb5b6b118f