### PR TITLE
Normaliza almacenamiento de deals

### DIFF
--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,15 +1,85 @@
-import { jsonb, pgTable, timestamp, varchar, integer } from "drizzle-orm/pg-core";
+import {
+  boolean,
+  doublePrecision,
+  integer,
+  jsonb,
+  pgTable,
+  serial,
+  text,
+  timestamp,
+  varchar
+} from "drizzle-orm/pg-core";
 
-export const pipedriveDeals = pgTable("pipedrive_deals", {
+export const deals = pgTable("deals", {
   dealId: integer("deal_id").primaryKey(),
-  title: varchar("title", { length: 255 }).notNull(),
-  clientName: varchar("client_name", { length: 255 }),
+  title: text("title").notNull(),
+  clientId: integer("client_id"),
+  clientName: text("client_name"),
+  sede: text("sede"),
+  address: text("address"),
+  caes: text("caes"),
+  fundae: text("fundae"),
+  hotelPernocta: text("hotel_pernocta"),
   pipelineId: integer("pipeline_id"),
-  pipelineName: varchar("pipeline_name", { length: 255 }),
-  wonDate: varchar("won_date", { length: 128 }),
-  data: jsonb("data").notNull(),
+  pipelineName: text("pipeline_name"),
+  wonDate: text("won_date"),
   createdAt: timestamp("created_at").defaultNow(),
   updatedAt: timestamp("updated_at").defaultNow()
+});
+
+export const dealFormations = pgTable("deal_formations", {
+  id: serial("id").primaryKey(),
+  dealId: integer("deal_id").references(() => deals.dealId, { onDelete: "cascade" }),
+  value: text("value").notNull(),
+  position: integer("position").notNull().default(0),
+  createdAt: timestamp("created_at").defaultNow()
+});
+
+export const dealProducts = pgTable("deal_products", {
+  dealProductId: integer("deal_product_id").primaryKey(),
+  dealId: integer("deal_id").references(() => deals.dealId, { onDelete: "cascade" }),
+  productId: integer("product_id"),
+  name: text("name").notNull(),
+  code: text("code"),
+  quantity: doublePrecision("quantity"),
+  itemPrice: doublePrecision("item_price"),
+  recommendedHours: doublePrecision("recommended_hours"),
+  recommendedHoursRaw: text("recommended_hours_raw"),
+  isTraining: boolean("is_training").notNull().default(false),
+  position: integer("position").notNull().default(0),
+  createdAt: timestamp("created_at").defaultNow(),
+  updatedAt: timestamp("updated_at").defaultNow()
+});
+
+export const dealNotes = pgTable("deal_notes", {
+  noteId: varchar("note_id", { length: 255 }).primaryKey(),
+  dealId: integer("deal_id").references(() => deals.dealId, { onDelete: "cascade" }),
+  content: text("content").notNull(),
+  createdAtText: text("created_at_text"),
+  authorName: text("author_name"),
+  source: varchar("source", { length: 32 }).notNull().default("deal"),
+  productId: integer("product_id"),
+  dealProductId: integer("deal_product_id"),
+  position: integer("position").notNull().default(0),
+  productPosition: integer("product_position"),
+  createdAt: timestamp("created_at").defaultNow()
+});
+
+export const dealAttachments = pgTable("deal_attachments", {
+  attachmentId: varchar("attachment_id", { length: 255 }).primaryKey(),
+  dealId: integer("deal_id").references(() => deals.dealId, { onDelete: "cascade" }),
+  name: text("name").notNull(),
+  url: text("url").notNull(),
+  downloadUrl: text("download_url"),
+  fileType: text("file_type"),
+  addedAtText: text("added_at_text"),
+  addedBy: text("added_by"),
+  source: varchar("source", { length: 32 }).notNull().default("deal"),
+  productId: integer("product_id"),
+  dealProductId: integer("deal_product_id"),
+  position: integer("position").notNull().default(0),
+  productPosition: integer("product_position"),
+  createdAt: timestamp("created_at").defaultNow()
 });
 
 export const sharedState = pgTable("shared_state", {


### PR DESCRIPTION
## Summary
- reemplaza la tabla `pipedrive_deals` por un esquema normalizado para deals, formaciones, productos, notas y adjuntos
- reimplementa la persistencia de deals en la función de Netlify para usar las nuevas tablas e hidratar los registros completos al leerlos
- asegura que las operaciones de guardado y borrado borren o actualicen las tablas relacionadas dentro de transacciones

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d55211efb483289713540f52796fb6