### PR TITLE
Align header navigation to left

### DIFF
--- a/src/components/layout/HeaderBar.tsx
+++ b/src/components/layout/HeaderBar.tsx
@@ -19,7 +19,7 @@ const HeaderBar = ({ activeKey, onNavigate }: HeaderBarProps) => (
         <Navbar.Toggle aria-controls="app-header-navigation" />
         <Navbar.Collapse
           id="app-header-navigation"
-          className="justify-content-lg-end mt-3 mt-lg-0"
+          className="justify-content-lg-start mt-3 mt-lg-0"
         >
           <Nav
             activeKey={activeKey}
@@ -28,7 +28,7 @@ const HeaderBar = ({ activeKey, onNavigate }: HeaderBarProps) => (
                 onNavigate(eventKey);
               }
             }}
-            className="nav-tabs-clean flex-column flex-lg-row ms-lg-auto"
+            className="nav-tabs-clean flex-column flex-lg-row"
             role="tablist"
           >
             <Nav.Item>


### PR DESCRIPTION
## Summary
- align the header navigation collapse to the left on large screens
- remove the auto-start margin that pushed the navigation tabs to the right

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5600d43a08328b9f0e81bca416a3f