### PR TITLE
Align scripts with npm usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "build": "vite build",
     "preview": "vite preview",
     "build:ts": "tsc --project tsconfig.sync.json",
-    "sync:deal": "pnpm run build:ts && node dist/src/sync/index.js",
+    "sync:deal": "npm run build:ts && node dist/src/sync/index.js",
     "lint": "eslint --ext .ts src/sync",
     "format": "eslint --ext .ts src/sync --fix",
-    "test": "pnpm run build:ts && node --test dist/src/sync/__tests__/mappings.test.js"
+    "test": "npm run build:ts && node --test dist/src/sync/__tests__/mappings.test.js"
   },
   "dependencies": {
     "@fullcalendar/daygrid": "^6.1.15",


### PR DESCRIPTION
## Summary
- update package scripts to invoke npm instead of pnpm so the project uses a single package manager

## Testing
- not run (npm install failed with 403 from registry)


------
https://chatgpt.com/codex/tasks/task_e_68d595324c2083289ec51eee6adb5af6