### PR TITLE
Call sync function when uploading deal

### DIFF
--- a/src/services/deals.ts
+++ b/src/services/deals.ts
@@ -233,6 +233,32 @@ export const fetchDealById = async (
   return deal;
 };
 
+type SyncDealResponse = {
+  ok: boolean;
+  message?: string;
+};
+
+export const syncDeal = async (dealId: number): Promise<void> => {
+  const response = await fetch('/.netlify/functions/api/deals/sync', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ dealId })
+  });
+
+  let payload: SyncDealResponse | null = null;
+
+  try {
+    payload = (await response.json()) as SyncDealResponse;
+  } catch (error) {
+    console.error('No se pudo interpretar la respuesta al sincronizar el presupuesto', error);
+  }
+
+  if (!response.ok || !payload?.ok) {
+    const message = payload?.message ?? 'No se pudo sincronizar el presupuesto solicitado.';
+    throw new Error(message);
+  }
+};
+
 export const persistDeal = async (deal: DealRecord): Promise<DealRecord> => {
   const response = await fetch(NETLIFY_DEALS_ENDPOINT, {
     method: 'PUT',


### PR DESCRIPTION
## Summary
- invoke the Netlify sync function from the "Subir Deal" handler and refresh the deals query instead of mutating local state
- add a dedicated service helper to call the sync endpoint and surface API errors

## Testing
- npm run build *(fails: local npm install blocked by 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d5bd3345608328a8139537a5d15620