### PR TITLE
Add budget import workflow for Presupuestos tab

### DIFF
--- a/db/migrations/0001_add_products_quantity.sql
+++ b/db/migrations/0001_add_products_quantity.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "products" ADD COLUMN IF NOT EXISTS "quantity" integer;

--- a/db/migrations/meta/0000_snapshot.json
+++ b/db/migrations/meta/0000_snapshot.json
@@ -429,6 +429,12 @@
           "notNull": false,
           "default": false
         },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp",

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1758900014051,
       "tag": "0000_puzzling_legion",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1758900014052,
+      "tag": "0001_add_products_quantity",
+      "breakpoints": false
     }
   ]
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,27 +1,68 @@
 // db/schema.ts
-import { pgTable, serial, text, integer, boolean, timestamp } from 'drizzle-orm/pg-core'
+import {
+  bigint,
+  boolean,
+  integer,
+  pgTable,
+  serial,
+  text,
+  timestamp,
+  uniqueIndex,
+} from 'drizzle-orm/pg-core'
 
-// Tabla deals normalizada
-export const deals = pgTable('deals', {
-  id: serial('id').primaryKey(),
-  title: text('title'),
-  value: integer('value'),
-  pipeline_id: integer('pipeline_id'),
-  org_id: integer('org_id'),
-  person_id: integer('person_id'),
-  add_time: timestamp('add_time', { withTimezone: true }),
-  update_time: timestamp('update_time', { withTimezone: true }),
+export const deals = pgTable(
+  'deals',
+  {
+    id: bigint('id', { mode: 'number' }).primaryKey(),
+    pipedriveId: bigint('pipedrive_id', { mode: 'number' }).notNull(),
+    title: text('title').notNull(),
+    pipelineId: integer('pipeline_id').notNull(),
+    status: text('status'),
+    orgId: bigint('org_id', { mode: 'number' }),
+    personId: bigint('person_id', { mode: 'number' }),
+    sede: text('sede'),
+    dealDirection: text('deal_direction'),
+    caes: boolean('caes'),
+    fundae: boolean('fundae'),
+    hotelPernocta: boolean('hotel_pernocta'),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
+  },
+  (table) => ({
+    pipedriveIdIdx: uniqueIndex('uniq_deals_pipedrive').on(table.pipedriveId),
+  })
+)
 
-  // ✅ Campos normalizados
-  sede: text('sede'),
-  hotel_pernocta: boolean('hotel_pernocta'),
-  deal_direction: text('deal_direction'), // podemos tipar como enum 'in' | 'out'
+export const organizations = pgTable('organizations', {
+  id: bigint('id', { mode: 'number' }).primaryKey(),
+  name: text('name').notNull(),
+  address: text('address'),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
 })
 
-// Ejemplo de otra tabla ya existente (sessions)
+export const persons = pgTable('persons', {
+  id: bigint('id', { mode: 'number' }).primaryKey(),
+  name: text('name').notNull(),
+  email: text('email'),
+  phone: text('phone'),
+  orgId: bigint('org_id', { mode: 'number' }),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+})
+
+export const products = pgTable('products', {
+  id: bigint('id', { mode: 'number' }).primaryKey(),
+  code: text('code').notNull(),
+  name: text('name').notNull(),
+  price: integer('price'),
+  dealId: bigint('deal_id', { mode: 'number' }),
+  isTraining: boolean('is_training').default(false),
+  quantity: integer('quantity'),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+})
+
 export const sessions = pgTable('sessions', {
   id: serial('id').primaryKey(),
-  dealId: integer('deal_id').references(() => deals.id),
+  dealId: bigint('deal_id', { mode: 'number' }).references(() => deals.id),
   trainerId: integer('trainer_id'),
   sede: text('sede'),
   startAt: timestamp('start_at', { withTimezone: true }),

--- a/netlify/functions/deals.ts
+++ b/netlify/functions/deals.ts
@@ -1,5 +1,14 @@
 import { Hono } from 'hono'
+import { neon } from '@neondatabase/serverless'
+import { drizzle } from 'drizzle-orm/neon-http'
+import { desc, eq, inArray } from 'drizzle-orm'
 import { PIPEDRIVE_FIELDS } from '../../src/shared/pipedriveFields'
+import * as schema from '../../db/schema'
+
+type DealRow = typeof schema.deals.$inferSelect
+type ProductRow = typeof schema.products.$inferSelect
+type OrganizationRow = typeof schema.organizations.$inferSelect
+type PersonRow = typeof schema.persons.$inferSelect
 
 const PIPEDRIVE_BASE = process.env.PIPEDRIVE_API_BASE?.replace(/\/+$/, '') || 'https://api.pipedrive.com/v1'
 const PIPEDRIVE_TOKEN = process.env.PIPEDRIVE_API_TOKEN
@@ -7,6 +16,14 @@ const PIPEDRIVE_TOKEN = process.env.PIPEDRIVE_API_TOKEN
 if (!PIPEDRIVE_TOKEN) {
   console.warn('[deals] Missing PIPEDRIVE_API_TOKEN')
 }
+
+const DATABASE_URL = process.env.DATABASE_URL
+if (!DATABASE_URL) {
+  console.warn('[deals] Missing DATABASE_URL')
+}
+
+const sql = DATABASE_URL ? neon(DATABASE_URL) : undefined
+const db = sql ? drizzle(sql, { schema }) : undefined
 
 type PDDeal = {
   id: number
@@ -17,13 +34,30 @@ type PDDeal = {
   person_id?: number | null
   add_time?: string
   update_time?: string
+  org_name?: string | null
+  person_name?: string | null
   [k: string]: any // campos custom
 }
 
 type PDProductAttachment = {
+  id?: number
   item_price?: number
   quantity?: number
   product?: { code?: string; name?: string }
+}
+
+type PDOrganization = {
+  id: number
+  name?: string | null
+  address?: string | null
+}
+
+type PDPerson = {
+  id: number
+  name?: string | null
+  email?: string | null
+  phone?: string | null
+  org_id?: number | null
 }
 
 const app = new Hono()
@@ -59,6 +93,296 @@ async function getDealProducts(dealId: number) {
   const extras = mapped.filter((p) => !p.code?.startsWith('form-'))
   return { form, extras, all: mapped }
 }
+
+async function getOrganization(organizationId: number) {
+  if (!organizationId) return null
+  try {
+    return await pd<PDOrganization>(`/organizations/${organizationId}`)
+  } catch (error) {
+    console.error('[deals] No se pudo cargar la organización', organizationId, error)
+    return null
+  }
+}
+
+async function getPerson(personId: number) {
+  if (!personId) return null
+  try {
+    return await pd<PDPerson>(`/persons/${personId}`)
+  } catch (error) {
+    console.error('[deals] No se pudo cargar la persona', personId, error)
+    return null
+  }
+}
+
+const parseBooleanField = (value: unknown): boolean | null => {
+  if (typeof value === 'boolean') {
+    return value
+  }
+
+  if (typeof value === 'number') {
+    if (Number.isNaN(value)) {
+      return null
+    }
+
+    return value === 1
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    if (!normalized) return null
+    if (['1', 'true', 't', 'si', 'sí', 'yes'].includes(normalized)) return true
+    if (['0', 'false', 'f', 'no'].includes(normalized)) return false
+  }
+
+  return null
+}
+
+const extractEntityId = (entity: unknown): number | null => {
+  if (typeof entity === 'number') {
+    return entity
+  }
+
+  if (entity && typeof entity === 'object') {
+    const candidate = entity as { id?: unknown; value?: unknown }
+    if (typeof candidate.id === 'number') {
+      return candidate.id
+    }
+
+    if (typeof candidate.value === 'number') {
+      return candidate.value
+    }
+  }
+
+  return null
+}
+
+const buildStoredDeal = (
+  deal: DealRow,
+  { organization, person, products }: {
+    organization?: OrganizationRow | null
+    person?: PersonRow | null
+    products?: ProductRow[]
+  } = {}
+) => ({
+  id: deal.id,
+  pipedriveId: deal.pipedriveId,
+  title: deal.title,
+  clientName: organization?.name ?? person?.name ?? null,
+  products: (products ?? []).map((product) => ({
+    code: product.code ?? '',
+    name: product.name ?? '',
+    quantity: product.quantity ?? 1,
+  })),
+})
+
+app.get('/imported', async (c) => {
+  try {
+    if (!db) throw new Error('DB not initialized')
+
+    const rows = await db
+      .select({
+        deal: schema.deals,
+        organization: schema.organizations,
+        person: schema.persons,
+      })
+      .from(schema.deals)
+      .leftJoin(schema.organizations, eq(schema.deals.orgId, schema.organizations.id))
+      .leftJoin(schema.persons, eq(schema.deals.personId, schema.persons.id))
+      .orderBy(desc(schema.deals.updatedAt))
+
+    const dealIds = rows.map((row) => row.deal.id)
+
+    const products = dealIds.length
+      ? await db
+          .select()
+          .from(schema.products)
+          .where(inArray(schema.products.dealId, dealIds))
+      : []
+
+    const productMap = products.reduce<Record<number, ProductRow[]>>((acc, product) => {
+      if (product.dealId == null) {
+        return acc
+      }
+
+      const bucket = acc[product.dealId] ?? []
+      bucket.push(product)
+      acc[product.dealId] = bucket
+      return acc
+    }, {})
+
+    const response = rows.map((row) =>
+      buildStoredDeal(row.deal, {
+        organization: row.organization,
+        person: row.person,
+        products: productMap[row.deal.id] ?? [],
+      })
+    )
+
+    return c.json(response)
+  } catch (err: any) {
+    console.error('[GET /api/deals/imported] error', err)
+    return c.json({ error: err.message }, 500)
+  }
+})
+
+app.post('/import', async (c) => {
+  try {
+    if (!db) throw new Error('DB not initialized')
+
+    const body = await c.req.json()
+    const rawDealId = body?.dealId ?? body?.id ?? body?.pipedriveId
+    const dealId = Number(rawDealId)
+
+    if (!Number.isFinite(dealId) || dealId <= 0) {
+      return c.json({ error: 'Debe indicar un número de presupuesto válido.' }, 400)
+    }
+
+    const deal = normalizeDeal(await pd<PDDeal>(`/deals/${dealId}`))
+    const organizationId = extractEntityId(deal.org_id)
+    const personId = extractEntityId(deal.person_id)
+
+    const [organization, person, productAttachments] = await Promise.all([
+      organizationId ? getOrganization(organizationId) : Promise.resolve(null),
+      personId ? getPerson(personId) : Promise.resolve(null),
+      getDealProducts(deal.id),
+    ])
+
+    const clientName = organization?.name ?? deal.org_name ?? person?.name ?? deal.person_name ?? null
+
+    if (organizationId && (organization || clientName)) {
+      const name = organization?.name ?? deal.org_name ?? clientName ?? ''
+
+      await db
+        .insert(schema.organizations)
+        .values({
+          id: organizationId,
+          name,
+          address: organization?.address ?? null,
+        })
+        .onConflictDoUpdate({
+          target: schema.organizations.id,
+          set: {
+            name,
+            address: organization?.address ?? null,
+          },
+        })
+    }
+
+    if (personId && (person || deal.person_name)) {
+      const name = person?.name ?? deal.person_name ?? ''
+      await db
+        .insert(schema.persons)
+        .values({
+          id: personId,
+          name,
+          email: person?.email ?? null,
+          phone: person?.phone ?? null,
+          orgId: person?.org_id ?? organizationId ?? null,
+        })
+        .onConflictDoUpdate({
+          target: schema.persons.id,
+          set: {
+            name,
+            email: person?.email ?? null,
+            phone: person?.phone ?? null,
+            orgId: person?.org_id ?? organizationId ?? null,
+          },
+        })
+    }
+
+    const storedDealValues = {
+      id: deal.id,
+      pipedriveId: deal.id,
+      title: deal.title ?? `Presupuesto ${deal.id}`,
+      pipelineId: deal.pipeline_id ?? 0,
+      status: deal.status ?? null,
+      orgId: organizationId ?? null,
+      personId: personId ?? null,
+      sede: (deal as Record<string, unknown>)[PIPEDRIVE_FIELDS.SEDE] as string | null,
+      dealDirection: typeof deal.deal_direction === 'string' ? deal.deal_direction : null,
+      caes: parseBooleanField((deal as Record<string, unknown>)[PIPEDRIVE_FIELDS.CAES]),
+      fundae: parseBooleanField((deal as Record<string, unknown>)[PIPEDRIVE_FIELDS.FUNDAE]),
+      hotelPernocta: parseBooleanField((deal as Record<string, unknown>)[PIPEDRIVE_FIELDS.HOTEL_PERNOCTA]),
+    }
+
+    const [storedDeal] = await db
+      .insert(schema.deals)
+      .values(storedDealValues)
+      .onConflictDoUpdate({
+        target: schema.deals.id,
+        set: storedDealValues,
+      })
+      .returning()
+
+    await db.delete(schema.products).where(eq(schema.products.dealId, storedDeal.id))
+
+    const allProducts = productAttachments.all ?? []
+    if (allProducts.length > 0) {
+      const productRows = allProducts
+        .filter((item) => item.id != null)
+        .map((item) => ({
+          id: item.id!,
+          dealId: storedDeal.id,
+          code: item.product?.code ?? '',
+          name: item.product?.name ?? '',
+          price: item.item_price != null ? Number(item.item_price) : null,
+          isTraining: item.product?.code?.startsWith('form-') ?? false,
+          quantity: item.quantity != null ? Number(item.quantity) : null,
+        }))
+
+      if (productRows.length > 0) {
+        for (const row of productRows) {
+          await db
+            .insert(schema.products)
+            .values(row)
+            .onConflictDoUpdate({
+              target: schema.products.id,
+              set: {
+                dealId: row.dealId,
+                code: row.code,
+                name: row.name,
+                price: row.price,
+                isTraining: row.isTraining,
+                quantity: row.quantity,
+              },
+            })
+        }
+      }
+    }
+
+    const [row] = await db
+      .select({
+        deal: schema.deals,
+        organization: schema.organizations,
+        person: schema.persons,
+      })
+      .from(schema.deals)
+      .leftJoin(schema.organizations, eq(schema.deals.orgId, schema.organizations.id))
+      .leftJoin(schema.persons, eq(schema.deals.personId, schema.persons.id))
+      .where(eq(schema.deals.id, storedDeal.id))
+      .limit(1)
+
+    const latestProducts = await db
+      .select()
+      .from(schema.products)
+      .where(eq(schema.products.dealId, storedDeal.id))
+
+    if (!row) {
+      throw new Error('No se pudo recuperar el presupuesto importado')
+    }
+
+    const response = buildStoredDeal(row.deal, {
+      organization: row.organization,
+      person: row.person,
+      products: latestProducts,
+    })
+
+    return c.json(response)
+  } catch (err: any) {
+    console.error('[POST /api/deals/import] error', err)
+    return c.json({ error: err.message ?? 'No se pudo importar el presupuesto.' }, 500)
+  }
+})
 
 // GET /api/deals
 app.get('/', async (c) => {

--- a/src/components/deals/DealsBoard.tsx
+++ b/src/components/deals/DealsBoard.tsx
@@ -1,34 +1,243 @@
-import { useState } from 'react'
-import DealDetailModal from './DealDetailModal'
-import { DealRecord, fetchDeals } from '../../services/deals'
+import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react'
+import Alert from 'react-bootstrap/Alert'
+import Button from 'react-bootstrap/Button'
+import Form from 'react-bootstrap/Form'
+import Modal from 'react-bootstrap/Modal'
+import Spinner from 'react-bootstrap/Spinner'
+import Stack from 'react-bootstrap/Stack'
+import Table from 'react-bootstrap/Table'
+import { CalendarEvent } from '../../services/calendar'
+import {
+  ImportedDealRecord,
+  fetchImportedDeals,
+  importDealById,
+} from '../../services/deals'
 
-export function DealsBoard() {
-  const [deals, setDeals] = useState<DealRecord[]>([])
-  const [selected, setSelected] = useState<DealRecord | null>(null)
+interface DealsBoardProps {
+  events: CalendarEvent[]
+  onUpdateSchedule: (dealId: number, events: CalendarEvent[]) => void
+  dealIdFilter: string
+  onDealIdFilterChange: (value: string) => void
+  onDealNotFound: (dealId: number) => void
+  onKnownDealIdsChange: (dealIds: number[]) => void
+}
 
-  // Aquí podrías usar useEffect para cargar deals con fetchDeals()
+const DealsBoard = ({
+  dealIdFilter,
+  onDealIdFilterChange,
+  onKnownDealIdsChange,
+}: DealsBoardProps) => {
+  const [deals, setDeals] = useState<ImportedDealRecord[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const [importValue, setImportValue] = useState('')
+  const [importError, setImportError] = useState<string | null>(null)
+  const [isImporting, setIsImporting] = useState(false)
+
+  const loadDeals = useCallback(async () => {
+    try {
+      setIsLoading(true)
+      setLoadError(null)
+      const response = await fetchImportedDeals()
+      setDeals(response)
+      onKnownDealIdsChange(response.map((deal) => deal.id))
+    } catch (error) {
+      console.error('No se pudieron cargar los presupuestos importados', error)
+      setLoadError(
+        error instanceof Error
+          ? error.message
+          : 'No se pudieron cargar los presupuestos. Inténtalo de nuevo más tarde.'
+      )
+    } finally {
+      setIsLoading(false)
+    }
+  }, [onKnownDealIdsChange])
+
+  useEffect(() => {
+    void loadDeals()
+  }, [loadDeals])
+
+  const handleOpenModal = useCallback(() => {
+    setImportError(null)
+    setImportValue('')
+    setIsModalOpen(true)
+  }, [])
+
+  const handleCloseModal = useCallback(() => {
+    if (isImporting) {
+      return
+    }
+
+    setIsModalOpen(false)
+    setImportError(null)
+    setImportValue('')
+  }, [isImporting])
+
+  const handleImportSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+
+      const trimmed = importValue.trim()
+      const parsed = Number(trimmed)
+
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        setImportError('Introduce un número de presupuesto válido.')
+        return
+      }
+
+      try {
+        setIsImporting(true)
+        setImportError(null)
+        await importDealById(parsed)
+        await loadDeals()
+        setIsModalOpen(false)
+        setImportValue('')
+      } catch (error) {
+        console.error('No se pudo importar el presupuesto', error)
+        setImportError(
+          error instanceof Error
+            ? error.message
+            : 'No se pudo importar el presupuesto. Inténtalo de nuevo más tarde.'
+        )
+      } finally {
+        setIsImporting(false)
+      }
+    },
+    [importValue, loadDeals]
+  )
+
+  const filteredDeals = useMemo(() => {
+    const normalized = dealIdFilter.trim().toLowerCase()
+    if (!normalized) {
+      return deals
+    }
+
+    return deals.filter((deal) => {
+      const dealIdMatches = String(deal.pipedriveId).includes(normalized)
+      const titleMatches = deal.title.toLowerCase().includes(normalized)
+      const clientMatches = (deal.clientName ?? '').toLowerCase().includes(normalized)
+      return dealIdMatches || titleMatches || clientMatches
+    })
+  }, [dealIdFilter, deals])
 
   return (
-    <div>
-      <h3>Deals</h3>
-      <ul>
-        {deals.map((d) => (
-          <li key={d.id} onClick={() => setSelected(d)}>
-            {d.title}
-          </li>
-        ))}
-      </ul>
+    <Stack gap={3}>
+      <Stack direction="horizontal" gap={2} className="flex-wrap">
+        <Button variant="primary" onClick={handleOpenModal}>
+          Subir Presupuesto
+        </Button>
+        <Form className="ms-lg-auto mt-3 mt-lg-0">
+          <Form.Control
+            value={dealIdFilter}
+            onChange={(event) => onDealIdFilterChange(event.currentTarget.value)}
+            placeholder="Buscar por número, título o cliente"
+            aria-label="Buscar presupuesto"
+          />
+        </Form>
+      </Stack>
 
-      {selected && (
-        <DealDetailModal
-          deal={selected}
-          notes={[]} // sustituir por datos reales
-          attachments={[]} // sustituir por datos reales
-          sessions={[]} // sustituir por datos reales
-          onClose={() => setSelected(null)}
-        />
-      )}
-    </div>
+      {loadError && <Alert variant="danger">{loadError}</Alert>}
+
+      <div className="table-responsive">
+        <Table striped hover responsive>
+          <thead>
+            <tr>
+              <th style={{ width: '12%' }}>Deal</th>
+              <th style={{ width: '30%' }}>Título</th>
+              <th style={{ width: '25%' }}>Cliente</th>
+              <th>Productos</th>
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading && deals.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="py-4 text-center text-muted">
+                  <Spinner animation="border" size="sm" className="me-2" />
+                  Cargando presupuestos...
+                </td>
+              </tr>
+            ) : filteredDeals.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="py-4 text-center text-muted">
+                  {dealIdFilter.trim()
+                    ? 'No hay presupuestos que coincidan con la búsqueda.'
+                    : 'Aún no se ha importado ningún presupuesto.'}
+                </td>
+              </tr>
+            ) : (
+              filteredDeals.map((deal) => (
+                <tr key={deal.id}>
+                  <td>{deal.pipedriveId}</td>
+                  <td>{deal.title}</td>
+                  <td>{deal.clientName ?? '—'}</td>
+                  <td>
+                    {deal.products.length === 0 ? (
+                      <span className="text-muted">Sin productos</span>
+                    ) : (
+                      <ul className="mb-0 ps-3">
+                        {deal.products.map((product) => {
+                          const quantityLabel = product.quantity > 1 ? ` x${product.quantity}` : ''
+                          const key = `${product.code}-${product.name}`
+                          return (
+                            <li key={key}>
+                              {product.name}
+                              {quantityLabel}
+                            </li>
+                          )
+                        })}
+                      </ul>
+                    )}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </Table>
+      </div>
+
+      <Modal show={isModalOpen} onHide={handleCloseModal} centered>
+        <Form onSubmit={handleImportSubmit}>
+          <Modal.Header closeButton={!isImporting}>
+            <Modal.Title>Importar presupuesto</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <Stack gap={3}>
+              <p className="mb-0 text-muted">
+                Introduce el número del presupuesto en Pipedrive que quieres importar.
+              </p>
+              <Form.Group controlId="importDealId">
+                <Form.Label>Número de presupuesto</Form.Label>
+                <Form.Control
+                  type="number"
+                  min={1}
+                  required
+                  value={importValue}
+                  onChange={(event) => setImportValue(event.currentTarget.value)}
+                  disabled={isImporting}
+                />
+              </Form.Group>
+              {importError && <Alert variant="danger" className="mb-0">{importError}</Alert>}
+            </Stack>
+          </Modal.Body>
+          <Modal.Footer>
+            <Button variant="secondary" onClick={handleCloseModal} disabled={isImporting}>
+              Cancelar
+            </Button>
+            <Button type="submit" variant="primary" disabled={isImporting}>
+              {isImporting ? (
+                <>
+                  <Spinner animation="border" size="sm" className="me-2" />
+                  Importando...
+                </>
+              ) : (
+                'Importar'
+              )}
+            </Button>
+          </Modal.Footer>
+        </Form>
+      </Modal>
+    </Stack>
   )
 }
 


### PR DESCRIPTION
## Summary
- extend the database schema with product quantity support for imported deals
- expose Netlify endpoints to import a Pipedrive budget into the database and list saved budgets
- add the "Subir Presupuesto" modal and table in the Presupuestos tab backed by the new API

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d80506b33c83288b2ff041ff729219